### PR TITLE
Don't send duplicate messages.

### DIFF
--- a/djangular/static/js/djng-websocket.js
+++ b/djangular/static/js/djng-websocket.js
@@ -80,7 +80,7 @@ angular.module('ng.django.websocket', []).provider('djangoWebsocket', function()
 		}
 
 		function listener(newValue, oldValue) {
-			if (newValue !== undefined) {
+			if (newValue !== undefined && newValue != oldValue) {
 				ws.send(JSON.stringify(newValue));
 			}
 		}
@@ -101,7 +101,8 @@ angular.module('ng.django.websocket', []).provider('djangoWebsocket', function()
 				connect(parts.join(''));
 				scope[collection] = scope[collection] || {};
 				deferred.promise.then(function() {
-					scope.$watchCollection(collection, listener);
+					//scope.$watchCollection(collection, listener);
+					scope.$watch(collection, listener, true);  // watchCollection has bug https://github.com/angular/angular.js/issues/2621
 				});
 				return deferred.promise;
 			}


### PR DESCRIPTION
Switch to using watch because watchCollection because of https://github.com/angular/angular.js/issues/2621
Allows us to see when the value changes.

Note - this does not fully fix bug 15, - there is either a bug in django-websocket-redis or we are using it incorrectly.   

Symptom:  if you edit a field quickly, the the server will continually send us the last few edits.
