### PR TITLE
Python 3 compatibility for CRUD view and tests

### DIFF
--- a/djangular/views/crud.py
+++ b/djangular/views/crud.py
@@ -45,11 +45,11 @@ class NgCRUDView(JSONBaseMixin, FormView):
             elif request.method == 'DELETE':
                 return self.ng_delete(request, *args, **kwargs)
         except self.model.DoesNotExist as e:
-            return self.error_json_response(str(e), 404)
+            return self.error_json_response(e.args[0], 404)
         except NgMissingParameterError as e:
-            return self.error_json_response(e.message)
+            return self.error_json_response(e.args[0])
         except JSONResponseException as e:
-            return self.error_json_response(e.message, e.status_code)
+            return self.error_json_response(e.args[0], e.status_code)
         except ValidationError as e:
             if hasattr(e, 'error_dict'):
                 return self.error_json_response('Form not valid', detail=e.message_dict)
@@ -101,7 +101,7 @@ class NgCRUDView(JSONBaseMixin, FormView):
         kwargs = super(NgCRUDView, self).get_form_kwargs()
         # Since angular sends data in JSON rather than as POST parameters, the default data (request.POST)
         # is replaced with request.body that contains JSON encoded data
-        kwargs['data'] = json.loads(self.request.body)
+        kwargs['data'] = json.loads(self.request.body.decode('utf-8'))
         if 'pk' in self.request.GET or self.slug_field in self.request.GET:
             kwargs['instance'] = self.get_object()
         return kwargs

--- a/examples/server/tests/crud.py
+++ b/examples/server/tests/crud.py
@@ -53,7 +53,7 @@ class CRUDViewTest(TestCase):
         # CRUDTestViewWithFK
         request = self.factory.get('/crud/')
         response = CRUDTestViewWithFK.as_view()(request)
-        data = json.loads(response.content)
+        data = json.loads(response.content.decode('utf-8'))
         for obj in data:
             db_obj = DummyModel.objects.get(pk=obj['pk'])
             self.assertEqual(obj['name'], db_obj.name)
@@ -61,7 +61,7 @@ class CRUDViewTest(TestCase):
         # CRUDTestViewWithSlug
         request2 = self.factory.get('/crud/')
         response2 = CRUDTestViewWithSlug.as_view()(request2)
-        data2 = json.loads(response2.content)
+        data2 = json.loads(response2.content.decode('utf-8'))
         for obj in data2:
             db_obj = SimpleModel.objects.get(email=obj['email'])
             self.assertEqual(obj['name'], db_obj.name)
@@ -70,13 +70,13 @@ class CRUDViewTest(TestCase):
         # CRUDTestViewWithFK
         request = self.factory.get('/crud/?pk=1')
         response = CRUDTestViewWithFK.as_view()(request)
-        data = json.loads(response.content)
+        data = json.loads(response.content.decode('utf-8'))
         self.assertEqual(self.names[0], data['name'])
 
         # CRUDTestViewWithSlug
         request2 = self.factory.get('/crud/?email={0}'.format(self.emails[0]))
         response2 = CRUDTestViewWithSlug.as_view()(request2)
-        data2 = json.loads(response2.content)
+        data2 = json.loads(response2.content.decode('utf-8'))
         self.assertEqual(self.names[0], data2['name'])
 
     def test_ng_save_create(self):
@@ -85,12 +85,12 @@ class CRUDViewTest(TestCase):
                                     data=json.dumps({'name': 'Leonard'}),
                                     content_type='application/json')
         response = CRUDTestView.as_view()(request)
-        data = json.loads(response.content)
+        data = json.loads(response.content.decode('utf-8'))
         pk = data['pk']
 
         request2 = self.factory.get('/crud/?pk={0}'.format(pk))
         response2 = CRUDTestView.as_view()(request2)
-        data2 = json.loads(response2.content)
+        data2 = json.loads(response2.content.decode('utf-8'))
         self.assertEqual(data2['name'], 'Leonard')
 
         # CRUDTestViewWithSlug
@@ -101,7 +101,7 @@ class CRUDViewTest(TestCase):
 
         request4 = self.factory.get('/crud/?email={0}'.format('Leonard@example.com'))
         response4 = CRUDTestViewWithSlug.as_view()(request4)
-        data4 = json.loads(response4.content)
+        data4 = json.loads(response4.content.decode('utf-8'))
         self.assertEqual(data4['name'], 'Leonard')
 
         request5 = self.factory.post('/crud/',
@@ -109,7 +109,7 @@ class CRUDViewTest(TestCase):
                                     content_type='application/json')
         response5 = CRUDTestViewWithSlug.as_view()(request5)
         self.assertGreaterEqual(response5.status_code, 400)
-        data5 = json.loads(response5.content)
+        data5 = json.loads(response5.content.decode('utf-8'))
         self.assertTrue('detail' in data5 and 'email' in data5['detail'] and len(data5['detail']['email']) > 0)
 
     def test_ng_save_update(self):
@@ -118,12 +118,12 @@ class CRUDViewTest(TestCase):
                                     data=json.dumps({'pk': 1, 'name': 'John2'}),
                                     content_type='application/json')
         response = CRUDTestView.as_view()(request)
-        data = json.loads(response.content)
+        data = json.loads(response.content.decode('utf-8'))
         self.assertEqual(data['name'], 'John2')
 
         request2 = self.factory.get('/crud/?pk=1')
         response2 = CRUDTestView.as_view()(request2)
-        data2 = json.loads(response2.content)
+        data2 = json.loads(response2.content.decode('utf-8'))
         self.assertEqual(data2['name'], 'John2')
 
         # CRUDTestViewWithSlug
@@ -131,13 +131,13 @@ class CRUDViewTest(TestCase):
                                     data=json.dumps({'name': 'John', 'email': 'John2@example.com'}),
                                     content_type='application/json')
         response3 = CRUDTestViewWithSlug.as_view()(request3)
-        data3 = json.loads(response3.content)
+        data3 = json.loads(response3.content.decode('utf-8'))
         self.assertEqual(data3['name'], 'John')
         self.assertEqual(data3['email'], 'John2@example.com')
 
         request4 = self.factory.get('/crud/?email=John2@example.com')
         response4 = CRUDTestViewWithSlug.as_view()(request4)
-        data4 = json.loads(response4.content)
+        data4 = json.loads(response4.content.decode('utf-8'))
         self.assertEqual(data4['name'], 'John')
 
         request5 = self.factory.post('/crud/?pk=3',  # Modifying "Chris"
@@ -145,19 +145,19 @@ class CRUDViewTest(TestCase):
                                     content_type='application/json')
         response5 = CRUDTestViewWithSlug.as_view()(request5)
         self.assertGreaterEqual(response5.status_code, 400)
-        data5 = json.loads(response5.content)
+        data5 = json.loads(response5.content.decode('utf-8'))
         self.assertTrue('detail' in data5 and 'email' in data5['detail'] and len(data5['detail']['email']) > 0)
 
     def test_ng_delete(self):
         # CRUDTestViewWithFK
         request = self.factory.delete('/crud/?pk=1')
         response = CRUDTestViewWithFK.as_view()(request)
-        data = json.loads(response.content)
+        data = json.loads(response.content.decode('utf-8'))
         deleted_name = data['name']
 
         request2 = self.factory.get('/crud/')
         response2 = CRUDTestViewWithFK.as_view()(request2)
-        data2 = json.loads(response2.content)
+        data2 = json.loads(response2.content.decode('utf-8'))
         for obj in data2:
             self.assertTrue(deleted_name != obj['name'])
 


### PR DESCRIPTION
`Exception` in Python 3 no longer has a `message` attribute. Due to differences in Python 2 and 3, applying `str()` to the exception would not work reliably either. It seems that using `args[0]` is the safest choice, except for `ValidationError` which has a `message` attribute on its own.

Additionally there have been some changes for decoding the request and response contents, for the same reasons as outlined in #41.
