### PR TITLE
Add parameter with key name to ungettext_lazy call

### DIFF
--- a/djangular/forms/field_mixins.py
+++ b/djangular/forms/field_mixins.py
@@ -33,12 +33,14 @@ class DefaultFieldMixin(object):
             if getattr(item, 'code', None) == 'min_length':
                 message = ungettext_lazy(
                     'Ensure this value has at least %(limit_value)d character',
-                    'Ensure this value has at least %(limit_value)d characters')
+                    'Ensure this value has at least %(limit_value)d characters',
+                    'limit_value')
                 errors.append(('$error.minlength', message % {'limit_value': self.min_length}))
             if getattr(item, 'code', None) == 'max_length':
                 message = ungettext_lazy(
                     'Ensure this value has at most %(limit_value)d character',
-                    'Ensure this value has at most %(limit_value)d characters')
+                    'Ensure this value has at most %(limit_value)d characters',
+                    'limit_value')
                 errors.append(('$error.maxlength', message % {'limit_value': self.max_length}))
         return errors
 


### PR DESCRIPTION
We need to pass argument with key of dict to ungettext_lazy, otherwise we have exception
"unsupported operand type(s) for %: 'dict' and 'int'".

Here code from django/utils/translation/**init**.py

``` python
def lazy_number(func, resultclass, number=None, **kwargs):
    if isinstance(number, six.integer_types):
        kwargs['number'] = number
        proxy = lazy(func, resultclass)(**kwargs)
    else:
        class NumberAwareString(resultclass):
            def __mod__(self, rhs):
                if isinstance(rhs, dict) and number:
                    try:
                        number_value = rhs[number]
                    except KeyError:
                        raise KeyError('Your dictionary lacks key \'%s\'. '
                                                'Please provide it, because it is required to '
                                                'determine whether string is singular or plural.'
                                                % number)
                else:
                    number_value = rhs
                    kwargs['number'] = number_value
                    translated = func(**kwargs)
                    try:
                        translated = translated % rhs
                    except TypeError:
                        # String doesn't contain a placeholder for the number
                        pass
                    return translated
         proxy = lazy(lambda **kwargs: NumberAwareString(), NumberAwareString)(**kwargs)
         return proxy
```
