### PR TITLE
Updated csrf documentation

### DIFF
--- a/docs/csrf-protection.rst
+++ b/docs/csrf-protection.rst
@@ -10,69 +10,27 @@ tag csrf_token_ to render a hidden input field containing the token, inside each
 method POST.
 
 When it comes to making an Ajax request, it normally is not possible to pass that token using a
-Javascript object, because scripts usually are static and no secret can be added dynamically. To
-effectively solve that problem in a DRY manner, there are two similar possibilities.
+Javascript object, because scripts usually are static and no secret can be added dynamically.
+AngularJS natively supports CSRF protection, only some minor configuration is required to work with Django.
 
 
-Set header with X-CSRFToken via Cookie
---------------------------------------
-To access data from cookies in AngularJS, the additional dependency ``angular-cookies.js`` must be
-included after ``angular.js``:
+Configure Angular for Django's CSRF protection
+----------------------------------------------
+Angular looks for ``XSRF-TOKEN`` cookie and submits it in ``X-XSRF-TOKEN`` http header, while Django sets ``csrftoken``
+cookie and expects ``X-CSRFToken`` http header. All we have to do is change the name of cookie and header Angular uses.
+This is best done in ``config`` block:
 
-.. code-block:: html
-
-	<script src="angular-cookies.js">
-
-During the initialization of an AngularJS application, the `method run`_ must be called to copy the
-CSRF-Token:
 
 .. code-block:: javascript
 
-	var my_app = angular.module('myApp', [/* other dependencies */, 'ngCookies']).run(function($http, $cookies) {
-	    $http.defaults.headers.post['X-CSRFToken'] = $cookies.csrftoken;
+	var my_app = angular.module('myApp', [/* dependencies */]).config(function($httpProvider) {
+            $httpProvider.defaults.xsrfCookieName = 'csrftoken';
+            $httpProvider.defaults.xsrfHeaderName = 'X-CSRFToken';
 	});
 
 When using this approach, ensure that the ``CSRF`` cookie is *not* configured as HTTP_ONLY_,
 otherwise for security reasons that value can't be accessed from JavaScript.
 
-
-Set header with X-CSRFToken via templatetag
--------------------------------------------
-When the ``CSRF`` cookie is configured as HTTP_ONLY_, the CSRFToken must be set using the special
-templatetag ``csrf_value`` offered by **django-angular**. During initialization, that security token
-can be hard coded into a template:
-
-.. code-block:: html
-
-	{% load djangular_tags %}
-	
-	<script>
-	var my_app = angular.module('myApp', [/* other dependencies */]).config(function($httpProvider) {
-	    $httpProvider.defaults.headers.common['X-CSRFToken'] = '{% csrf_value %}';
-	});
-	</script>
-
-The latter is my preferred method, as it liberates me from including the additional dependency
-``angular-cookies.js``.
-
-
-Disable Cross Site Request Forgery protection
----------------------------------------------
-**Warning:** Not suitable for production environments!
-
-Optionally, if the above methods do not work, add the following method to the view handling the
-Ajax request:
-
-.. code-block:: python
-
-	from django.views.decorators.csrf import csrf_exempt
-	
-	@csrf_exempt
-	def dispatch(self, *args, **kwargs):
-	    return super(MyView, self).dispatch(*args, **kwargs)
-
-This disables Cross Site Request Forgery protection for Ajax request. However, it is **strongly
-discouraged**, so **use this at your own risk!**
 
 
 .. _Cross Site Request Forgeries: http://www.squarefree.com/securitytips/web-developers.html#CSRF


### PR DESCRIPTION
As discussed in #143, updated the ``csrf-protection`` in documentation.

Also removed the ``{% csrf_value %}`` approach, since it doesn't work with subsequent ajax requests, without "normal" page reloads. ``csrftoken`` cookie changes on every request, while the header would only be set on page load. Angular (and other AJAX heavy) apps can't work with ``HTTP_ONLY`` cookies.