### PR TITLE
Radio input required issue

### DIFF
--- a/djangular/forms/widgets.py
+++ b/djangular/forms/widgets.py
@@ -81,9 +81,9 @@ class CheckboxSelectMultiple(widgets.CheckboxSelectMultiple):
 class RadioFieldRendererMixin(object):
     def __init__(self, name, value, attrs, choices):
         attrs.pop('djng-error', None)
-        self.field_attrs = []
+        self.field_attrs = [format_html('ng-form="{0}"', name)]
         if attrs.pop('radio_select_required', False):
-            self.field_attrs.append(format_html('validate-multiple-fields="{0}"', name))
+            attrs.update({'required': ''})
         super(RadioFieldRendererMixin, self).__init__(name, value, attrs, choices)
 
 


### PR DESCRIPTION
If you look at the initial console output of the plunker you can see what's happening

http://plnkr.co/edit/7tWnDtnXfss4v8rkvO0m?p=preview

As each radio button is added to the form, as they all share the same name, they replace one another. So the last radio button added is the one that's retrieved from the `formController` by `form.cheese`.

If you select each radio button in order, you can see a side effect of this, as only the last one ('maybe') sets the `ngModelController` to `$dirty`. 

This issue is fixed by `validate-multiple-fields`, but i'd like to propose another solution that doesn't require that directive to handle a `RadioSelect`.

**Solution**

Firstly rather than using `validate-multiple-fields` to handle a 'required' group of radio buttons, you can use the `required` attribute on each radio button.

http://plnkr.co/edit/w0tUBsuxXSNqAkPhNkaB?p=preview

Then to remove the `$dirty`/`$pristine` issue, you can wrap the elements in an `ngForm` of the same name, so that all view/error state is bound to that instead, which is then updated by each input.

http://plnkr.co/edit/WmezNdFd4SU5x44A1uoZ?p=preview

As each radio buttons `ngModel` is bound to the same property on scope, the resulting data structure still matches what's expected by the server.