### PR TITLE
Get examples working with 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,4 +33,3 @@ before_script:
 script:
  - pushd . && cd client && grunt travis-ci && popd
  - pushd . && cd examples && $MIGRATE && ./manage.py test server && popd
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
   - DJANGO=1.5.10 MIGRATE='true'
   - DJANGO=1.6.10 MIGRATE='true'
   - DJANGO=1.7.7 MIGRATE='./manage.py migrate'
+  - DJANGO=1.8 MIGRATE='./manage.py migrate'
 
 install:
   - pip install -q Django==$DJANGO

--- a/djangular/forms/angular_base.py
+++ b/djangular/forms/angular_base.py
@@ -45,6 +45,14 @@ class TupleErrorList(UserList, list):
     li_format = '<li ng-show="{0}.{1}" class="{2}">{3}</li>'
     li_format_bind = '<li ng-show="{0}.{1}" class="{2}" ng-bind="{0}.{3}"></li>'
 
+    def __init__(self, initlist=None, error_class=None):
+        super(TupleErrorList, self).__init__(initlist)
+
+        if error_class is None:
+            self.error_class = 'errorlist'
+        else:
+            self.error_class = 'errorlist {}'.format(error_class)
+
     def as_data(self):
         return ValidationError(self.data).error_list
 

--- a/djangular/forms/widgets.py
+++ b/djangular/forms/widgets.py
@@ -22,13 +22,14 @@ class ChoiceFieldRenderer(widgets.ChoiceFieldRenderer):
 
 
 class CheckboxChoiceInput(widgets.CheckboxChoiceInput):
-    def tag(self):
+    def tag(self, attrs=None):
+        attrs = attrs or self.attrs
         name = '{0}.{1}'.format(self.name, self.choice_value)
-        tag_attrs = dict(self.attrs, type=self.input_type, name=name, value=self.choice_value)
-        if 'id' in self.attrs:
-            tag_attrs['id'] = '{0}_{1}'.format(self.attrs['id'], self.index)
-        if 'ng-model' in self.attrs:
-            tag_attrs['ng-model'] = '{0}.{1}'.format(self.attrs['ng-model'], self.choice_value)
+        tag_attrs = dict(attrs, type=self.input_type, name=name, value=self.choice_value)
+        if 'id' in attrs:
+            tag_attrs['id'] = '{0}_{1}'.format(attrs['id'], self.index)
+        if 'ng-model' in attrs:
+            tag_attrs['ng-model'] = '{0}.{1}'.format(attrs['ng-model'], self.choice_value)
         if self.is_checked():
             tag_attrs['checked'] = 'checked'
         return format_html('<input{0} />', flatatt(tag_attrs))

--- a/djangular/styling/bootstrap3/widgets.py
+++ b/djangular/styling/bootstrap3/widgets.py
@@ -75,9 +75,10 @@ class RadioChoiceInput(widgets.RadioChoiceInput):
         label_tag = super(RadioChoiceInput, self).render(name, value, choices)
         return format_html('<div class="radio">{}</div>', label_tag)
 
-    def tag(self):
-        tag_attrs = dict(self.attrs, type=self.input_type, name=self.name, value=self.choice_value)
-        if 'id' in self.attrs:
+    def tag(self, attrs=None):
+        attrs = attrs or self.attrs
+        tag_attrs = dict(attrs, type=self.input_type, name=self.name, value=self.choice_value)
+        if 'id' in attrs:
             tag_attrs['id'] = '{0}_{1}'.format(tag_attrs['id'], self.index)
         if self.is_checked():
             tag_attrs['checked'] = 'checked'

--- a/djangular/views/crud.py
+++ b/djangular/views/crud.py
@@ -63,7 +63,7 @@ class NgCRUDView(JSONBaseMixin, FormView):
         """
         Build ModelForm from model
         """
-        return modelform_factory(self.model)
+        return modelform_factory(self.model, exclude=[])
 
     def build_json_response(self, data, **kwargs):
         return self.json_response(self.serialize_queryset(data), separators=(',', ':'), **kwargs)


### PR DESCRIPTION
Hi,

Django 1.8 has updated a few of it's methods that seem to be overridden in django-angular - by adding the optional method parameters to the methods (and adding an explicit init) we mirror the new django methods and are no longer failing. I would be very surprised if this broke anything but I suspect there will be a few more such cases before full compatibility with 1.8 can be declared.