### PR TITLE
Move reverseUrl into reverse() scope

### DIFF
--- a/client/src/js/ng-django-urls.js
+++ b/client/src/js/ng-django-urls.js
@@ -10,13 +10,14 @@
         - djangoUrl.reverse('home', [2]);
      */
     var djngUrls = angular.module('ng.django.urls', []);
-    var reverseUrl = '/angular/reverse/';
 
     djngUrls.service('djangoUrl', function () {
         /*
          Functions from angular.js source, not public available
          See: https://github.com/angular/angular.js/issues/7429
          */
+        
+        this.reverseUrl = '/angular/reverse/';
         function forEachSorted(obj, iterator, context) {
             var keys = sortedKeys(obj);
             for (var i = 0; i < keys.length; i++) {
@@ -50,7 +51,7 @@
 
         // Service public interface
         this.reverse = function (url_name, args_or_kwargs) {
-            var url = buildUrl(reverseUrl, {djng_url_name: url_name});
+            var url = buildUrl(this.reverseUrl, {djng_url_name: url_name});
             /*
              Django wants arrays in query params encoded the following way: a = [1,2,3] -> ?a=1&a=2$a=3
              buildUrl function doesn't natively understand lists in params, so in case of a argument array


### PR DESCRIPTION
*Suggestion:* In order to use a URL whose top level is not `/` but is `/myprojectname`, django-angular will try to send a URL that starts with `/angular/reverse/...`. This will break the app with a 404 error. This should actually be built as `myProjectName+reverseUrl`.

I fixed this in my own project:

0. [Simple] code changes as noted below in diffs. Essentially, move `reverseUrl` into the `djangoUrl` service as a property.
0. Ensure that `djangular.urls` are included in the URLconf, such as:
`url(r'^angular/', include('djangular.urls', namespace='djangular')),`
0. Inject the djangoUrl service into a directive that can initialize its `reverseUrl` property. For a single page I chain the following directive to the `.module()`.

*HTML:*
```
<body init-djng url-root="/myProjectName">
```
*Angular app.js:*
```
      .directive('initDjng',function(){
          return {
              controller: ['djangoUrl','$scope',function(djangoUrl,$scope){
                      djangoUrl.reverseUrl = $scope.urlRoot + djangoUrl.reverseUrl;
              }],
              restrict: 'A',
              scope: { urlRoot : '@urlRoot' }
          };
      });
```

**EDIT:** *Deleted a step here that was wrong and stated to add something to "the app." It is taken care of in step 1.*

With this in place, I can set `<... init-djing url-root='....'>` to myProjectName so that it's routed to the right URL.