### PR TITLE
Tweaks the addNgModelDirective so it replaces any hyphens in the name attribute with underscores, creating (hopefully) valid JS identifiers.

### DIFF
--- a/client/src/js/ng-django-forms.js
+++ b/client/src/js/ng-django-forms.js
@@ -32,7 +32,7 @@ function addNgModelDirective() {
 				var modelName;
 				if (!formCtrl || angular.isUndefined(formCtrl.$name) || element.prop('type') === 'hidden' || angular.isUndefined(attr.name) || angular.isDefined(attr.ngModel))
 					return;
-				modelName = 'dmy' + Math.abs(hashCode(formCtrl.$name)) +'.' + attr.name;
+				modelName = 'dmy' + Math.abs(hashCode(formCtrl.$name)) +'.' + attr.name.replace(/-/g, "_");;
 				attr.$set('ngModel', modelName);
 				$compile(element, null, 9999)(scope);
 			}


### PR DESCRIPTION
The addNgModelDirective function automatically adds an ngModel directive to any input tag that's missing one. The directive is generated from a hash of the formCtrl name and the 'name' attribute on the form element. That causes problems if the name attribute contained a hyphen because JS identifiers can't contain hyphens and so neither can ngModel attributes. If a name did have hyphen, it would cause Angular to produce 'noAssign' errors because the generated identifier is not valid JS and cannot be assigned to. That issue came up for me with name attributes that are autogenerated by Django, e.g. on formsets.

This tiny patch should fix that problem.