### PR TITLE
fix RemovedInDjango19Warning

### DIFF
--- a/djangular/forms/angular_model.py
+++ b/djangular/forms/angular_model.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-from django.forms.util import ErrorDict
+if django.VERSION[:2] >= (1, 7):
+    from django.forms.utils import ErrorDict
+else:
+    from django.forms.util import ErrorDict
 from django.utils.html import format_html
 from djangular.forms.angular_base import NgFormBaseMixin, SafeTuple
 


### PR DESCRIPTION
The is a pull request to fix the deprecation warning for Django 1.9 for 

`from django.forms.util import ErrorDict`