### PR TITLE
djngError directive causes errors in angular>=1.3.0

### DIFF
--- a/client/src/js/ng-django-forms.js
+++ b/client/src/js/ng-django-forms.js
@@ -48,14 +48,18 @@ djng_forms_module.directive('djngError', function() {
 		require: '?^form',
 		link: function(scope, element, attrs, formCtrl) {
 			var boundField;
-			if (!formCtrl || angular.isUndefined(attrs.name) || attrs.djngError !== 'bound-field')
+			var field = angular.isElement(element) ? element[0] : null;
+			if (!field || !formCtrl || angular.isUndefined(attrs.name) || attrs.djngError !== 'bound-field')
 				return;
 			boundField = formCtrl[attrs.name];
 			boundField.$setValidity('bound', false);
 			boundField.$parsers.push(function(value) {
-				// set bound field into valid state after changing value
-				boundField.$setValidity('bound', true);
-				element.removeAttr('djng-error');
+				if (value !== field.defaultValue) {
+					// set bound field into valid state after changing value
+					boundField.$setValidity('bound', true);
+					element.removeAttr('djng-error');
+				}
+				return value;
 			});
 		}
 	};


### PR DESCRIPTION
The parser removes `$error.bound` but causes `$error.parse` instead.
I think the reason is `angular1.3.0-rc.4` changes how `$parsers` is registered (See https://github.com/angular/angular.js/blob/master/CHANGELOG.md#bug-fixes-37).
My fix is to always return value.

Also, bounded field value may not be an empty string, e.g., unique constraint violation.
My fix is to remove `$error.bound` only if new value does not equal to old value.