### PR TITLE
Unquote URL before providing it to PATH_INFO

### DIFF
--- a/djangular/middleware.py
+++ b/djangular/middleware.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 from django.core.handlers.wsgi import WSGIRequest
 from django.core.urlresolvers import reverse
+from django.utils.http import unquote
 
 
 class DjangularUrlMiddleware(object):
@@ -36,7 +37,7 @@ class DjangularUrlMiddleware(object):
                 if param.startswith('djng_url_kwarg_'):
                     url_kwargs[param[15:]] = request.GET[param]  # [15:] to remove 'djng_url_kwarg' prefix
 
-            url = reverse(url_name, args=url_args, kwargs=url_kwargs, urlconf=self.urlconf)
+            url = unquote(reverse(url_name, args=url_args, kwargs=url_kwargs, urlconf=self.urlconf))
             assert not url.startswith(self.ANGULAR_REVERSE), "Prevent recursive requests"
 
             # rebuild the request object with a different environ


### PR DESCRIPTION
reverse() creates an RFC 3986 quoted URL path, but PATH_INFO expects an
unquoted path. This was causing arguments that had spaces in their value
to show up as %20 in a view when access through the Angular URL reversal
path.

PATH_INFO from the regular URL lookup:
     u'PATH_INFO': u'/report/user1-my space name/',

PATH_INFO from /angular/reverse/ lookup:
     u'PATH_INFO': u'/report/user1-my%20space%20name/',