### PR TITLE
fix #95 Form validation errors doesn't show up when using prefix in form

### DIFF
--- a/djangular/forms/angular_validation.py
+++ b/djangular/forms/angular_validation.py
@@ -29,7 +29,7 @@ class NgFormValidationMixin(NgFormBaseMixin):
         errors = super(NgFormValidationMixin, self).get_field_errors(bound_field)
         if bound_field.is_hidden:
             return errors
-        identifier = format_html('{0}.{1}', self.form_name, self.add_prefix(bound_field.name))
+        identifier = format_html('{0}[\'{1}\']', self.form_name, self.add_prefix(bound_field.name))
         potential_errors = bound_field.field.get_potential_errors()
         errors.extend([SafeTuple((identifier, self.field_error_css_classes, '$dirty', pe[0], 'invalid', force_text(pe[1])))
                        for pe in potential_errors])

--- a/examples/server/tests/test_validation.py
+++ b/examples/server/tests/test_validation.py
@@ -33,9 +33,9 @@ class NgFormValidationMixinTest(TestCase):
         else:
             self.assertEqual(len(lis), 4)
         attrib = dict(lis[0].attrib.items())
-        self.assertDictContainsSubset({'ng-show': self.form_name + '.first_name.$error.required'}, attrib)
+        self.assertDictContainsSubset({'ng-show': self.form_name + '[\'first_name\'].$error.required'}, attrib)
         attrib = dict(lis[1].attrib.items())
-        self.assertDictContainsSubset({'ng-show': self.form_name + six.u('.first_name.$error.minlength')}, attrib)
+        self.assertDictContainsSubset({'ng-show': self.form_name + six.u('[\'first_name\'].$error.minlength')}, attrib)
 
     def test_type(self):
         email_field = self.dom('input[name=email]')
@@ -57,13 +57,13 @@ class NgFormValidationMixinTest(TestCase):
     def test_field_as_ul(self):
         bf = self.subscription_form['email']
         ul_dirty = ''.join((
-            '<ul class="djng-form-control-feedback djng-field-errors" ng-show="U3Vic2NyaWJlRm9ybQ.email.$dirty" ng-cloak>',
-            '<li ng-show="U3Vic2NyaWJlRm9ybQ.email.$error.required" class="invalid">This field is required.</li>',
-            '<li ng-show="U3Vic2NyaWJlRm9ybQ.email.$error.email" class="invalid">Enter a valid email address.</li>',
-            '<li ng-show="U3Vic2NyaWJlRm9ybQ.email.$valid" class="valid"></li>'
+            '<ul class="djng-form-control-feedback djng-field-errors" ng-show="U3Vic2NyaWJlRm9ybQ[\'email\'].$dirty" ng-cloak>',
+            '<li ng-show="U3Vic2NyaWJlRm9ybQ[\'email\'].$error.required" class="invalid">This field is required.</li>',
+            '<li ng-show="U3Vic2NyaWJlRm9ybQ[\'email\'].$error.email" class="invalid">Enter a valid email address.</li>',
+            '<li ng-show="U3Vic2NyaWJlRm9ybQ[\'email\'].$valid" class="valid"></li>'
             '</ul>'))
         self.assertTrue(ul_dirty in bf.errors.as_ul())
-        ul_pristine = '<ul class="djng-form-control-feedback djng-field-errors" ng-show="U3Vic2NyaWJlRm9ybQ.email.$pristine" ng-cloak></ul>'
+        ul_pristine = '<ul class="djng-form-control-feedback djng-field-errors" ng-show="U3Vic2NyaWJlRm9ybQ[\'email\'].$pristine" ng-cloak></ul>'
         self.assertTrue(ul_pristine in bf.errors.as_ul())
 
     def test_field_as_text(self):


### PR DESCRIPTION
enclosed the scope variable name into string to avoid ambiguity.