### PR TITLE
Deprecated / removed in 1.9 warnings for Django>=1.8.x

### DIFF
--- a/djangular/core/urlresolvers.py
+++ b/djangular/core/urlresolvers.py
@@ -4,7 +4,10 @@ import warnings
 from inspect import isclass
 
 from django.utils import six
-from django.utils.module_loading import import_by_path
+try:
+    from django.utils.module_loading import import_string
+except ImportError:
+    from django.utils.module_loading import import_by_path as import_string
 from django.core.urlresolvers import (get_resolver, get_urlconf, get_script_prefix,
     get_ns_resolver, iri_to_uri, resolve, reverse, NoReverseMatch, RegexURLResolver, RegexURLPattern)
 from django.core.exceptions import ImproperlyConfigured
@@ -146,7 +149,7 @@ def get_all_remote_methods(resolver=None, ns_prefix=''):
         try:
             url = reverse(ns_prefix + name)
             resmgr = resolve(url)
-            ViewClass = import_by_path('{0}.{1}'.format(resmgr.func.__module__, resmgr.func.__name__))
+            ViewClass = import_string('{0}.{1}'.format(resmgr.func.__module__, resmgr.func.__name__))
             if isclass(ViewClass) and issubclass(ViewClass, JSONResponseMixin):
                 result[name] = _get_remote_methods_for(ViewClass, url)
         except (NoReverseMatch, ImproperlyConfigured):

--- a/djangular/forms/angular_base.py
+++ b/djangular/forms/angular_base.py
@@ -11,7 +11,10 @@ except ImportError:  # Python 2
 from django.forms import forms
 from django.http import QueryDict
 from django.utils import six
-from django.utils.importlib import import_module
+try:
+    from importlib import import_module
+except ImportError:
+    from django.utils.importlib import import_module
 from django.utils.html import format_html, format_html_join, escape
 from django.utils.encoding import python_2_unicode_compatible, force_text
 from django.utils.safestring import mark_safe, SafeText, SafeData

--- a/djangular/forms/angular_model.py
+++ b/djangular/forms/angular_model.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-from django.forms.util import ErrorDict
+try:
+    from django.forms.utils import ErrorDict
+except ImportError:
+    from django.forms.util import ErrorDict
 from django.utils.html import format_html
 from djangular.forms.angular_base import NgFormBaseMixin, SafeTuple
 

--- a/djangular/forms/widgets.py
+++ b/djangular/forms/widgets.py
@@ -5,7 +5,10 @@ from django.forms import widgets
 from django.utils.safestring import mark_safe
 from django.utils.encoding import force_text
 from django.utils.html import format_html
-from django.forms.util import flatatt
+try:
+    from django.forms.utils import flatatt
+except ImportError:
+    from django.forms.util import flatatt
 
 
 class ChoiceFieldRenderer(widgets.ChoiceFieldRenderer):

--- a/djangular/styling/bootstrap3/widgets.py
+++ b/djangular/styling/bootstrap3/widgets.py
@@ -3,7 +3,10 @@ from __future__ import unicode_literals
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 from django.utils.encoding import force_text
-from django.forms.util import flatatt
+try:
+    from django.forms.utils import flatatt
+except ImportError:
+    from django.forms.util import flatatt
 from django.forms import widgets
 from djangular.forms.widgets import (
     ChoiceFieldRenderer as DjngChoiceFieldRenderer, CheckboxChoiceInput as DjngCheckboxChoiceInput,


### PR DESCRIPTION
Fixed imports causing deprecated / removed in 1.9 warnings for Django>=1.8.x. Kept 1.6 backwards compatible