### PR TITLE
Rewrote __init__ method to properly extract form field values out of …

### DIFF
--- a/djangular/forms/angular_model.py
+++ b/djangular/forms/angular_model.py
@@ -33,7 +33,7 @@ class NgModelFormMixin(NgFormBaseMixin):
             self.ng_directives['ng-model'] = '%(model)s'
         self.prefix = kwargs.get('prefix')
         if self.prefix and data:
-            data = dict((self.add_prefix(name), value) for name, value in data.get(self.prefix).items())
+		data = dict((name, value) for (name, value) in data.items() if self.prefix in name)
         super(NgModelFormMixin, self).__init__(data, *args, **kwargs)
         if self.scope_prefix == self.form_name:
             raise ValueError("The form's name may not be identical with its scope_prefix")


### PR DESCRIPTION
…data dict when using several forms on one view.

Bugfixed Error 'NoneType object has no method items()'

The Problem was that if using more than one form on a view, prefixes must be used. Those prefixes will result in value string names like 'contacts.mobile' for a ContactsForm with prefix 'contacts' and field name mobile. 

As it seems for now, django adds all form field values in one single dict which must be seperated by the key values.