### PR TITLE
Support added for multiple flat forms

### DIFF
--- a/djangular/forms/angular_model.py
+++ b/djangular/forms/angular_model.py
@@ -34,9 +34,9 @@ class NgModelFormMixin(NgFormBaseMixin):
         self.prefix = kwargs.get('prefix')
         if self.prefix and data:
             if data.get(self.prefix):
-		data = {self.add_prefix(name): value for (name, value) in data.get(self.prefix).items()}
+                data = {self.add_prefix(name): value for (name, value) in data.get(self.prefix).items()}
             else:
-		data = {name : value for (name, value) in data.items() if name.startswith(self.prefix + '.')}	
+                data = {name : value for (name, value) in data.items() if name.startswith(self.prefix + '.')}	
         super(NgModelFormMixin, self).__init__(data, *args, **kwargs)
         if self.scope_prefix == self.form_name:
             raise ValueError("The form's name may not be identical with its scope_prefix")

--- a/djangular/forms/angular_model.py
+++ b/djangular/forms/angular_model.py
@@ -33,7 +33,10 @@ class NgModelFormMixin(NgFormBaseMixin):
             self.ng_directives['ng-model'] = '%(model)s'
         self.prefix = kwargs.get('prefix')
         if self.prefix and data:
-		data = dict((name, value) for (name, value) in data.items() if self.prefix in name)
+            if data.get(self.prefix):
+                data = dict((self.add_prefix(name), value) for (name, value) in data.get(self.prefix).items())
+            else:
+                data = dict((name, value) for (name, value) in data.items() if self.prefix in name)
         super(NgModelFormMixin, self).__init__(data, *args, **kwargs)
         if self.scope_prefix == self.form_name:
             raise ValueError("The form's name may not be identical with its scope_prefix")

--- a/djangular/forms/angular_model.py
+++ b/djangular/forms/angular_model.py
@@ -33,7 +33,7 @@ class NgModelFormMixin(NgFormBaseMixin):
             self.ng_directives['ng-model'] = '%(model)s'
         self.prefix = kwargs.get('prefix')
         if self.prefix and data:
-            data = dict((self.add_prefix(name), value) for name, value in data.get(self.prefix).items())
+		data = dict((name, value) for (name, value) in data.items() if self.prefix in name)
         super(NgModelFormMixin, self).__init__(data, *args, **kwargs)
         if self.scope_prefix == self.form_name:
             raise ValueError("The form's name may not be identical with its scope_prefix")

--- a/djangular/forms/angular_model.py
+++ b/djangular/forms/angular_model.py
@@ -34,9 +34,9 @@ class NgModelFormMixin(NgFormBaseMixin):
         self.prefix = kwargs.get('prefix')
         if self.prefix and data:
             if data.get(self.prefix):
-                data = dict((self.add_prefix(name), value) for (name, value) in data.get(self.prefix).items())
+		data = {self.add_prefix(name): value for (name, value) in data.get(self.prefix).items()}
             else:
-                data = dict((name, value) for (name, value) in data.items() if self.prefix in name)
+		data = {name : value for (name, value) in data.items() if name.startswith(self.prefix + '.')}	
         super(NgModelFormMixin, self).__init__(data, *args, **kwargs)
         if self.scope_prefix == self.form_name:
             raise ValueError("The form's name may not be identical with its scope_prefix")


### PR DESCRIPTION
While working on an application with a view in which 4 forms are placed, I have noticed that the NgModelFormMixin grabs the data to each form by looking up a list which is placed as a value in the response data dict with a key equals to the prefix of the nested form. This only applies if the Form is nested to a parent form.

For my case the forms are bundled together on view layer. So there is just one dict with all form data and just seperated by the prefix in the key name. 

This behaviour results in a 'NoneType has no method items()' error. To prevent this I have implemented a check if the data.get(self.prefix) is None. If so it will grab the data list by searching for all keys containing the prefix.