### PR TITLE
Fix prefix handling in NgModelFormMixin

### DIFF
--- a/djangular/forms/angular_base.py
+++ b/djangular/forms/angular_base.py
@@ -254,7 +254,7 @@ class NgFormBaseMixin(object):
 
     def add_prefix(self, field_name):
         """
-        Rewrite the model keys to use dots instead of dashes, since thats the syntax
+        Rewrite the model keys to use dots instead of dashes, since that's the syntax
         used in Angular models.
         """
         return self.prefix and ('%s.%s' % (self.prefix, field_name)) or field_name

--- a/djangular/forms/angular_model.py
+++ b/djangular/forms/angular_model.py
@@ -33,7 +33,7 @@ class NgModelFormMixin(NgFormBaseMixin):
             self.ng_directives['ng-model'] = '%(model)s'
         self.prefix = kwargs.get('prefix')
         if self.prefix and data:
-            data = dict((self.add_prefix(name), value) for name, value in data.get(self.prefix).items())
+            data = {name: value for name, value in data.items() if name.startswith(self.prefix + '.')}
         super(NgModelFormMixin, self).__init__(data, *args, **kwargs)
         if self.scope_prefix == self.form_name:
             raise ValueError("The form's name may not be identical with its scope_prefix")


### PR DESCRIPTION
If you have multiple forms in one page, and use Django's `prefix` attribute to distinguish them, Djangular will error out initializing the form:

    'NoneType' object has no attribute 'items'

The prefix-handling code within `NgModelFormMixin` was assuming that form data would be nested in a subdictionary by a prefix, like so:

```python
{'name': "Fred",
 'contact_info': {'name': 'Steve',
                  'phone': '555-1234'}
}
```

Instead, prefixed form data looks like this:
```python
{'name': "Fred",
 'contact_info.name': 'Steve',
 'contact_info.phone': '555-1234'
}
```

(Fields would normally be [`'contact_info-name'`][add_prefix] under Django 1.6-1.8, but Djangular overrides this to use a dot separator for Angular).

----------

I've tested this on Django 1.7 and 1.8. `_post_clean()` still works as expected.

[add_prefix]: https://github.com/django/django/blob/1.8.7/django/forms/forms.py#L186