### PR TITLE
request.environ['QUERY_STRING'] in UTF-8

### DIFF
--- a/djangular/middleware.py
+++ b/djangular/middleware.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 from django.core.handlers.wsgi import WSGIRequest
 from django.core.urlresolvers import reverse
 from django.utils.http import unquote
+from django.utils import six
 
 
 class DjangularUrlMiddleware(object):
@@ -40,6 +41,10 @@ class DjangularUrlMiddleware(object):
             query = request.GET.copy()
             query.pop('djng_url_name', None)
             query.pop('djng_url_args', None)
-            request.environ['QUERY_STRING'] = query.urlencode().encode('utf-8')
+            query_string = query.urlencode()
+            if six.PY3:
+                request.environ['QUERY_STRING'] = query_string
+            else:
+                request.environ['QUERY_STRING'] = query_string.encode('utf-8')
             new_request = WSGIRequest(request.environ)
             request.__dict__ = new_request.__dict__

--- a/djangular/middleware.py
+++ b/djangular/middleware.py
@@ -40,6 +40,6 @@ class DjangularUrlMiddleware(object):
             query = request.GET.copy()
             query.pop('djng_url_name', None)
             query.pop('djng_url_args', None)
-            request.environ['QUERY_STRING'] = query.urlencode()
+            request.environ['QUERY_STRING'] = query.urlencode().encode('utf-8')
             new_request = WSGIRequest(request.environ)
             request.__dict__ = new_request.__dict__


### PR DESCRIPTION
Instead of unicode, which breaks things. Solves #213.