### PR TITLE
Change the widget css class using a dictionary similar to field_css_classes

### DIFF
--- a/djangular/forms/angular_base.py
+++ b/djangular/forms/angular_base.py
@@ -173,12 +173,6 @@ class NgBoundField(forms.BoundField):
         else:
             css_classes = getattr(self.form, 'widget_css_classes', None)
         if css_classes:
-            if isinstance(css_classes, dict):
-                extra_css_classes = ''
-                for key in ('*', self.name):
-                    new_class = css_classes.get(key or None)
-                    extra_css_classes = new_class if new_class else extra_css_classes
-                css_classes = extra_css_classes
             attrs.update({'class': css_classes})
         return super(NgBoundField, self).as_widget(widget, attrs, only_initial)
 

--- a/djangular/forms/angular_base.py
+++ b/djangular/forms/angular_base.py
@@ -174,6 +174,9 @@ class NgBoundField(forms.BoundField):
             css_classes = getattr(self.form, 'widget_css_classes', None)
         if css_classes:
             attrs.update({'class': css_classes})
+        widget_classes = self.form.fields[self.name].widget.attrs.get('class', None)
+        if widget_classes:
+            attrs['class'] += ' ' + widget_classes
         return super(NgBoundField, self).as_widget(widget, attrs, only_initial)
 
     def label_tag(self, contents=None, attrs=None, label_suffix=None):

--- a/djangular/forms/angular_base.py
+++ b/djangular/forms/angular_base.py
@@ -173,6 +173,12 @@ class NgBoundField(forms.BoundField):
         else:
             css_classes = getattr(self.form, 'widget_css_classes', None)
         if css_classes:
+            if isinstance(css_classes, dict):
+                extra_css_classes = ''
+                for key in ('*', self.name):
+                    new_class = css_classes.get(key or None)
+                    extra_css_classes = new_class if new_class else extra_css_classes
+                css_classes = extra_css_classes
             attrs.update({'class': css_classes})
         return super(NgBoundField, self).as_widget(widget, attrs, only_initial)
 


### PR DESCRIPTION
This is a merge request to allow changing the css class for widgets using a dictionary key similar to field_css_classes. I need this to be able to add a datepicker class to certain form fields.