### PR TITLE
Fix widget class attribute being ignored

### DIFF
--- a/djangular/forms/angular_base.py
+++ b/djangular/forms/angular_base.py
@@ -176,7 +176,10 @@ class NgBoundField(forms.BoundField):
             attrs.update({'class': css_classes})
         widget_classes = self.form.fields[self.name].widget.attrs.get('class', None)
         if widget_classes:
-            attrs['class'] += ' ' + widget_classes
+            if attrs.get('class', None):
+                attrs['class'] += ' ' + widget_classes
+            else:
+                attrs.update({'class': widget_classes})
         return super(NgBoundField, self).as_widget(widget, attrs, only_initial)
 
     def label_tag(self, contents=None, attrs=None, label_suffix=None):


### PR DESCRIPTION
This is an updated pull request of #215. It checks if 'attrs' exists before changing the dict value.