### PR TITLE
Disable autoescape for pygment calls and set Angular version to 1.3.20

### DIFF
--- a/examples/server/templates/model-scope.html
+++ b/examples/server/templates/model-scope.html
@@ -50,7 +50,7 @@ name for you. The <code>form_name</code> must be different from <code>scope_pref
 AngularJS's internal form controller adds its own object to the scope, using the form's name and
 this <em>must</em> be different from the scope's content.</p>
 <p>In this example, an additional server-side validations has been added to the form: The method 
-<code>clean()</code> rejects the combination of ???John??? and ???Doe??? for the first- and last name
+<code>clean()</code> rejects the combination of “John” and “Doe” for the first- and last name
 respectively. Errors for a failed form validation are send back to the client and displayed on top
 of the form.</p>
 <p>Form data submitted by Ajax, is validated by the server using the same functionality. Errors

--- a/examples/server/templates/three-way-data-binding.html
+++ b/examples/server/templates/three-way-data-binding.html
@@ -46,7 +46,7 @@ how to propagate the Form's scope to a foreign browser</p>
 <p>With <b>django-angular</b> and the additional Django app
 <a href="https://github.com/jrief/django-websocket-redis">django-websocket-redis</a>, one can extend
 two-way data-binding to propagate all changes on a model, back and forward with a corresponding
-object stored on the server. This means, that the server ???sees??? whenever the model changes on the client
+object stored on the server. This means, that the server “sees” whenever the model changes on the client
 and can by itself, modify values on the client side at any time, without having the client
 to poll for new messages.</p>
 <p>This can be useful, when the server wants to inform the clients about asynchronous events such


### PR DESCRIPTION
Django autoescapes all function calls in templates by default. To get the pygment call to display properly, this needs to be turned off.

Also, there is no Angular 1.3.30 yet.