### PR TITLE
Fix select with edit (Issue #68).

### DIFF
--- a/client/src/js/ng-django-forms.js
+++ b/client/src/js/ng-django-forms.js
@@ -134,6 +134,9 @@ djng_forms_module.directive('ngModel', ['$log', function ($log) {
 				restoreInputField(modelCtrl, field);
 				break;
 			case 'SELECT':
+				modelCtrl.$formatters.push(function (val) {
+					return '' + val;
+				});
 				restoreSelectOptions(modelCtrl, field);
 				break;
 			case 'TEXTAREA':


### PR DESCRIPTION
The problem appears when you have a form (not bound) with choiceField (foreignkeys and m2m) and at some point, you initialize it with angular. What happens when you get a json serialized representation of your model is, if you have  foreignkey, you get the pk as a number. BUT, a select expects the value to be a string (!). Angular then adds a new option value to the select which make no sens.

In the angular docs, an example is shown with a convertToNumber directive. https://docs.angularjs.org/api/ng/directive/select   (last example on the page)
I only reuse the formatters part as we need to ensure it stays generic.

Cheers