### PR TITLE
Remove legacy djangular_tags.py file.

### DIFF
--- a/djng/templatetags/djangular_tags.py
+++ b/djng/templatetags/djangular_tags.py
@@ -1,6 +1,0 @@
-import warnings
-
-warnings.warn(
-    "Templatetags `djangular_tags` have been renamed to `djng_tags`."
-)
-from .djangular_tags import *


### PR DESCRIPTION
Loading the file prints a warning, which is annoying because django automatically loads templatetags libraries on startup.

The warning gets printed every time you start django, even though you never explicitly load the legacy djangular_tags module.

The module wasn't even working because it was recursively loading itself rather then the new djng_tags module.

A similar file has already been removed in https://github.com/jrief/django-angular/commit/f79fec4aef7232d69791d4d3b8ff213125199f60.