### PR TITLE
Avoid modifying form __init__ signature

### DIFF
--- a/djng/forms/angular_base.py
+++ b/djng/forms/angular_base.py
@@ -235,7 +235,7 @@ class NgFormBaseMixin(object):
     form_error_css_classes = 'djng-form-errors'
     field_error_css_classes = 'djng-field-errors'
 
-    def __init__(self, data=None, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         try:
             form_name = self.form_name
         except AttributeError:
@@ -245,11 +245,11 @@ class NgFormBaseMixin(object):
         error_class = kwargs.pop('error_class', TupleErrorList)
         kwargs.setdefault('error_class', error_class)
         self.convert_widgets()
-        if isinstance(data, QueryDict):
-            data = self.rectify_multipart_form_data(data.copy())
-        elif isinstance(data, dict):
-            data = self.rectify_ajax_form_data(data.copy())
-        super(NgFormBaseMixin, self).__init__(data=data, *args, **kwargs)
+        super(NgFormBaseMixin, self).__init__(*args, **kwargs)
+        if isinstance(self.data, QueryDict):
+            self.data = self.rectify_multipart_form_data(self.data.copy())
+        elif isinstance(self.data, dict):
+            self.data = self.rectify_ajax_form_data(self.data.copy())
 
     def __getitem__(self, name):
         "Returns a NgBoundField with the given name."

--- a/djng/forms/angular_model.py
+++ b/djng/forms/angular_model.py
@@ -20,7 +20,7 @@ class NgModelFormMixin(NgFormBaseMixin):
     """
     add_djng_error = False
 
-    def __init__(self, data=None, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         self.scope_prefix = kwargs.pop('scope_prefix', getattr(self, 'scope_prefix', None))
         self.ng_directives = {}
         for key in list(kwargs.keys()):
@@ -32,13 +32,13 @@ class NgModelFormMixin(NgFormBaseMixin):
                 raise TypeError('Meta.ng_model is not of type list')
         elif 'ng-model' not in self.ng_directives:
             self.ng_directives['ng-model'] = '%(model)s'
+        super(NgModelFormMixin, self).__init__(*args, **kwargs)
         self.prefix = kwargs.get('prefix')
-        if self.prefix and data:
-            if data.get(self.prefix):
-                data = {self.add_prefix(name): value for (name, value) in data.get(self.prefix).items()}
+        if self.prefix and self.data:
+            if self.data.get(self.prefix):
+                self.data = {self.add_prefix(name): value for (name, value) in self.data.get(self.prefix).items()}
             else:
-                data = {name : value for (name, value) in data.items() if name.startswith(self.prefix + '.')}	
-        super(NgModelFormMixin, self).__init__(data, *args, **kwargs)
+                self.data = {name: value for (name, value) in self.data.items() if name.startswith(self.prefix + '.')}
         if self.scope_prefix == self.form_name:
             raise ValueError("The form's name may not be identical with its scope_prefix")
 


### PR DESCRIPTION
#### Background

I am trying to use django-angular's `NgFormValidationMixin` with django's built-in [`AuthenticationForm`](https://docs.djangoproject.com/en/1.9/topics/auth/default/#django.contrib.auth.forms.AuthenticationForm). This is the code I am using:

```python
class LoginForm(NgFormValidationMixin, AuthenticationForm,
                metaclass=NgDeclarativeFieldsMetaclass):
    pass
```

When using this with django's built-in login view, I get the following error:

```
Traceback (most recent call last):
  File "/home/vagrant/.virtualenvs/opencraft/lib/python3.5/site-packages/djng/forms/angular_base.py", line 280, in non_field_errors
    errors = super(NgFormBaseMixin, self).non_field_errors()
  File "/home/vagrant/.virtualenvs/opencraft/lib/python3.5/site-packages/django/forms/forms.py", line 289, in non_field_errors
    return self.errors.get(NON_FIELD_ERRORS, self.error_class(error_class='nonfield'))
  File "/home/vagrant/.virtualenvs/opencraft/lib/python3.5/site-packages/django/forms/forms.py", line 153, in errors
    self.full_clean()
  File "/home/vagrant/.virtualenvs/opencraft/lib/python3.5/site-packages/django/forms/forms.py", line 362, in full_clean
    self._clean_fields()
  File "/home/vagrant/.virtualenvs/opencraft/lib/python3.5/site-packages/django/forms/forms.py", line 374, in _clean_fields
    value = field.widget.value_from_datadict(self.data, self.files, self.add_prefix(name))
  File "/home/vagrant/.virtualenvs/opencraft/lib/python3.5/site-packages/django/forms/widgets.py", line 231, in value_from_datadict
    return data.get(name)
AttributeError: 'WSGIRequest' object has no attribute 'get'
```

I did some digging and it turns out that django's login view passes a `request` argument to the form constructor. This breaks the `NgFormBaseMixin` constructor, which expects `data` as the first positional argument.

#### Proposal

This pull request modifies `NgFormBaseMixin.__init__` and `NgModelFormMixin.__init__` to not care about the `__init__` signature of the form they are mixin in with. This is accomplished by calling the superclass constructor first, then manipulating `self.data`.