### PR TITLE
Fix: When running test, errors like 'TemplateSyntaxError: 'sekizai_ta…

### DIFF
--- a/examples/server/settings.py
+++ b/examples/server/settings.py
@@ -28,6 +28,7 @@ INSTALLED_APPS = (
     'django.contrib.staticfiles',
     'djng',
     'server',
+    'sekizai',
 )
 
 USE_L10N = True


### PR DESCRIPTION
…gs' is not a valid tag library:'

It's the first time I encounter this error running the tests. Adding sekizai in the settings fixes it.

What Am I missing? @jkosir @jrief 