### PR TITLE
#284 Django 1.11 support

### DIFF
--- a/djng/compat.py
+++ b/djng/compat.py
@@ -1,0 +1,3 @@
+from django.forms import widgets
+
+HAS_CHOICE_FIELD_RENDERER = hasattr(widgets, 'ChoiceFieldRenderer')

--- a/djng/core/urlresolvers.py
+++ b/djng/core/urlresolvers.py
@@ -3,8 +3,12 @@ from __future__ import unicode_literals
 from inspect import isclass
 
 from django.utils import six
-from django.core.urlresolvers import (get_resolver, get_urlconf, resolve, reverse, NoReverseMatch)
 from django.core.exceptions import ImproperlyConfigured
+
+try:
+    from django.core.urlresolvers import (get_resolver, get_urlconf, resolve, reverse, NoReverseMatch)
+except ImportError:
+    from django.urls import (get_resolver, get_urlconf, resolve, reverse, NoReverseMatch)
 
 try:
     from django.utils.module_loading import import_string

--- a/djng/forms/angular_base.py
+++ b/djng/forms/angular_base.py
@@ -240,7 +240,7 @@ class NgFormBaseMixin(object):
             form_name = self.form_name
         except AttributeError:
             # if form_name is unset, then generate a pseudo unique name, based upon the class name
-            form_name = b64encode(six.b(self.__class__.__name__)).rstrip(six.b('='))
+            form_name = b64encode(six.b(self.__class__.__name__)).rstrip(six.b('=')).decode('utf-8')
         self.form_name = kwargs.pop('form_name', form_name)
         error_class = kwargs.pop('error_class', TupleErrorList)
         kwargs.setdefault('error_class', error_class)

--- a/djng/forms/angular_base.py
+++ b/djng/forms/angular_base.py
@@ -294,11 +294,8 @@ class NgFormBaseMixin(object):
         be rendered the AngularJS way.
         """
         for field in self.base_fields.values():
-            try:
+            if hasattr(field, 'get_converted_widget'):
                 new_widget = field.get_converted_widget()
-            except AttributeError:
-                pass
-            else:
                 if new_widget:
                     field.widget = new_widget
 

--- a/djng/forms/compat.py
+++ b/djng/forms/compat.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import json
+from django.forms import widgets
+from django.utils.safestring import mark_safe
+from django.utils.encoding import force_text
+from django.utils.html import format_html
+from .widgets import flatatt
+
+
+class ChoiceFieldRenderer(widgets.ChoiceFieldRenderer):
+    def render(self):
+        """
+        Outputs a <ul ng-form="name"> for this set of choice fields to nest an ngForm.
+        """
+        start_tag = format_html('<ul {0}>', mark_safe(' '.join(self.field_attrs)))
+        output = [start_tag]
+        for widget in self:
+            output.append(format_html('<li>{0}</li>', force_text(widget)))
+        output.append('</ul>')
+        return mark_safe('\n'.join(output))
+
+
+class CheckboxChoiceInput(widgets.CheckboxChoiceInput):
+    def tag(self, attrs=None):
+        attrs = attrs or self.attrs
+        name = '{0}.{1}'.format(self.name, self.choice_value)
+        tag_attrs = dict(attrs, type=self.input_type, name=name, value=self.choice_value)
+        if 'id' in attrs:
+            tag_attrs['id'] = '{0}_{1}'.format(attrs['id'], self.index)
+        if 'ng-model' in attrs:
+            tag_attrs['ng-model'] = "{0}['{1}']".format(attrs['ng-model'], self.choice_value)
+        if self.is_checked():
+            tag_attrs['checked'] = 'checked'
+        return format_html('<input{0} />', flatatt(tag_attrs))
+
+
+class CheckboxFieldRendererMixin(object):
+    def __init__(self, name, value, attrs, choices):
+        attrs.pop('djng-error', None)
+        self.field_attrs = [format_html('ng-form="{0}"', name)]
+        if attrs.pop('multiple_checkbox_required', False):
+            field_names = [format_html('{0}.{1}', name, choice) for choice, dummy in choices]
+            self.field_attrs.append(format_html('validate-multiple-fields="{0}"', json.dumps(field_names)))
+        super(CheckboxFieldRendererMixin, self).__init__(name, value, attrs, choices)
+
+
+class CheckboxFieldRenderer(CheckboxFieldRendererMixin, ChoiceFieldRenderer):
+    choice_input_class = CheckboxChoiceInput
+
+
+class CheckboxSelectMultiple(widgets.CheckboxSelectMultiple):
+    renderer = CheckboxFieldRenderer
+
+class RadioFieldRendererMixin(object):
+    def __init__(self, name, value, attrs, choices):
+        attrs.pop('djng-error', None)
+        self.field_attrs = []
+        if attrs.pop('radio_select_required', False):
+            self.field_attrs.append(format_html('validate-multiple-fields="{0}"', name))
+        super(RadioFieldRendererMixin, self).__init__(name, value, attrs, choices)
+
+
+class RadioFieldRenderer(RadioFieldRendererMixin, ChoiceFieldRenderer):
+    choice_input_class = widgets.RadioChoiceInput
+
+
+class RadioSelect(widgets.RadioSelect):
+    """
+    Form fields of type 'ChoiceField' using the widget 'RadioSelect' must behave
+    slightly different from the original. This widget overrides the default functionality.
+    """
+    renderer = RadioFieldRenderer
+
+    def get_field_attrs(self, field):
+        return {'radio_select_required': field.required}

--- a/djng/styling/bootstrap3/compat.py
+++ b/djng/styling/bootstrap3/compat.py
@@ -1,0 +1,106 @@
+from django.utils.html import format_html
+from django.utils.safestring import mark_safe
+from django.utils.encoding import force_text
+from django.forms import widgets
+
+from djng.forms.compat import (flatatt,
+    CheckboxSelectMultiple as DjngCheckboxSelectMultiple, RadioSelect as DjngRadioSelect,
+    ChoiceFieldRenderer as DjngChoiceFieldRenderer, CheckboxChoiceInput as DjngCheckboxChoiceInput,
+    CheckboxFieldRendererMixin, RadioFieldRendererMixin,
+)
+
+class ChoiceFieldRenderer(DjngChoiceFieldRenderer):
+    def render(self):
+        """
+        Outputs a <div ng-form="name"> for this set of choice fields to nest an ngForm.
+        """
+        start_tag = format_html('<div {}>', mark_safe(' '.join(self.field_attrs)))
+        output = [start_tag]
+        for widget in self:
+            output.append(force_text(widget))
+        output.append('</div>')
+        return mark_safe('\n'.join(output))
+
+
+class CheckboxInput(widgets.CheckboxInput):
+    def __init__(self, label, attrs=None, check_test=None):
+        # the label is rendered by the Widget class rather than by BoundField.label_tag()
+        self.choice_label = label
+        super(CheckboxInput, self).__init__(attrs, check_test)
+
+    def render(self, name, value, attrs=None):
+        attrs = attrs or self.attrs
+        label_attrs = ['class="checkbox-inline"']
+        if 'id' in self.attrs:
+            label_attrs.append(format_html('for="{}"', self.attrs['id']))
+        label_for = mark_safe(' '.join(label_attrs))
+        tag = super(CheckboxInput, self).render(name, value, attrs)
+        return format_html('<label {0}>{1} {2}</label>', label_for, tag, self.choice_label)
+
+
+class CheckboxChoiceInput(DjngCheckboxChoiceInput):
+    def render(self, name=None, value=None, attrs=None, choices=()):
+        label_tag = super(CheckboxChoiceInput, self).render(name, value, attrs, choices)
+        return format_html('<div class="checkbox">{}</div>', label_tag)
+
+
+class CheckboxInlineChoiceInput(CheckboxChoiceInput):
+    def render(self, name=None, value=None, attrs=None, choices=()):
+        name = name or self.name
+        value = value or self.value
+        attrs = attrs or self.attrs
+        label_attrs = ['class="checkbox-inline"']
+        if 'id' in self.attrs:
+            label_attrs.append(format_html('for="{0}_{1}"', self.attrs['id'], self.index))
+        label_for = mark_safe(' '.join(label_attrs))
+        return format_html('<label {0}>{1} {2}</label>', label_for, self.tag(), self.choice_label)
+
+
+class CheckboxFieldRenderer(CheckboxFieldRendererMixin, ChoiceFieldRenderer):
+    choice_input_class = CheckboxChoiceInput
+
+
+class CheckboxInlineFieldRenderer(CheckboxFieldRendererMixin, ChoiceFieldRenderer):
+    choice_input_class = CheckboxInlineChoiceInput
+
+
+class CheckboxSelectMultiple(DjngCheckboxSelectMultiple):
+    renderer = CheckboxInlineFieldRenderer
+
+
+class RadioChoiceInput(widgets.RadioChoiceInput):
+    def render(self, name=None, value=None, attrs=None, choices=()):
+        label_tag = super(RadioChoiceInput, self).render(name, value, choices)
+        return format_html('<div class="radio">{}</div>', label_tag)
+
+    def tag(self, attrs=None):
+        attrs = attrs or self.attrs
+        tag_attrs = dict(attrs, type=self.input_type, name=self.name, value=self.choice_value)
+        if 'id' in attrs:
+            tag_attrs['id'] = '{0}_{1}'.format(tag_attrs['id'], self.index)
+        if self.is_checked():
+            tag_attrs['checked'] = 'checked'
+        return format_html('<input{} />', flatatt(tag_attrs))
+
+
+class RadioInlineChoiceInput(widgets.RadioChoiceInput):
+    def render(self, name=None, value=None, attrs=None, choices=()):
+        name = name or self.name
+        value = value or self.value
+        attrs = attrs or self.attrs
+        label_attrs = ['class="radio-inline"']
+        if 'id' in self.attrs:
+            label_attrs.append(format_html('for="{0}_{1}"', self.attrs['id'], self.index))
+        label_for = mark_safe(' '.join(label_attrs))
+        return format_html('<label {0}>{1} {2}</label>', label_for, self.tag(), self.choice_label)
+
+
+class RadioFieldRenderer(RadioFieldRendererMixin, ChoiceFieldRenderer):
+    choice_input_class = RadioChoiceInput
+
+
+class RadioInlineFieldRenderer(RadioFieldRendererMixin, ChoiceFieldRenderer):
+    choice_input_class = RadioInlineChoiceInput
+
+class RadioSelect(DjngRadioSelect):
+    renderer = RadioFieldRenderer

--- a/djng/templates/djng/forms/widgets/attrs.html
+++ b/djng/templates/djng/forms/widgets/attrs.html
@@ -1,0 +1,1 @@
+{% for name, value in widget.attrs.items %}{% if value is not False %} {{ name }}{% if value is not True %}="{{ value }}"{% endif %}{% endif %}{% endfor %}

--- a/djng/templates/djng/forms/widgets/checkbox.html
+++ b/djng/templates/djng/forms/widgets/checkbox.html
@@ -1,0 +1,1 @@
+{% include "django/forms/widgets/input.html" %}

--- a/djng/templates/djng/forms/widgets/checkbox_option.html
+++ b/djng/templates/djng/forms/widgets/checkbox_option.html
@@ -1,0 +1,1 @@
+<label class="checkbox-inline" for="{{ widget.attrs.id }}">{% include "djng/forms/widgets/input.html" %}{{ widget.label }}</label>

--- a/djng/templates/djng/forms/widgets/checkbox_select.html
+++ b/djng/templates/djng/forms/widgets/checkbox_select.html
@@ -1,0 +1,4 @@
+{% with id=widget.attrs.id %}<ul{% if id %} id="{{ id }}"{% endif %}{% if widget.attrs.class %} class="{{ widget.attrs.class }}"{% endif %}{% for tag, value in widget.attrs.items %} {{ tag }}="{{ value }}" {% endfor %}>{% for group, options, index in widget.optgroups %}{% if group %} <li>{{ group }}<ul{% if id %} id="{{ id }}_{{ index }}"{% endif %}>{% endif %}{% for option in options %}
+    <li>{% include option.template_name with widget=option %}</li>{% endfor %}{% if group %}
+  </ul></li>{% endif %}{% endfor %}
+</ul>{% endwith %}

--- a/djng/templates/djng/forms/widgets/input.html
+++ b/djng/templates/djng/forms/widgets/input.html
@@ -1,0 +1,1 @@
+<input type="{{ widget.type }}" name="{{ widget.name }}" {% if widget.value != None %} value="{{ widget.value }}"{% endif %}{% include "djng/forms/widgets/attrs.html" %} />

--- a/djng/templates/djng/forms/widgets/input_option.html
+++ b/djng/templates/djng/forms/widgets/input_option.html
@@ -1,0 +1,1 @@
+{% if wrap_label %}<div class="radio"><label for="{{ widget.for_id }}">{% endif %}{% include "djng/forms/widgets/input.html" %}{% if wrap_label %} {{ widget.label }}</label></div>{% endif %}

--- a/djng/templates/djng/forms/widgets/multiple_input.html
+++ b/djng/templates/djng/forms/widgets/multiple_input.html
@@ -1,0 +1,5 @@
+{% with id=widget.attrs.id %}<ul{% if id %} id="{{ id }}"{% endif %}{% if widget.attrs.class %} class="{{ widget.attrs.class }}"{% endif %}>{% for group, options, index in widget.optgroups %}{% if group %}
+  <li>{{ group }}<ul{% if id %} id="{{ id }}_{{ index }}"{% endif %}>{% endif %}{% for option in options %}
+    <li>{% include option.template_name with widget=option %}</li>{% endfor %}{% if group %}
+  </ul></li>{% endif %}{% endfor %}
+</ul>{% endwith %}

--- a/djng/templates/djng/forms/widgets/radio.html
+++ b/djng/templates/djng/forms/widgets/radio.html
@@ -1,0 +1,1 @@
+{% include "djng/forms/widgets/checkbox_select.html" %}

--- a/djng/templates/djng/forms/widgets/radio_option.html
+++ b/djng/templates/djng/forms/widgets/radio_option.html
@@ -1,0 +1,1 @@
+{% include "djng/forms/widgets/input_option.html" %}

--- a/djng/templates/djng/styling/bootstrap3/checkbox_select.html
+++ b/djng/templates/djng/styling/bootstrap3/checkbox_select.html
@@ -1,0 +1,4 @@
+{% with id=widget.attrs.id %}<div{% for field, value in widget.attrs.items %} {{ field }}="{{ value }}"{% endfor %}>{% for group, options, index in widget.optgroups %}{% for option in options %}
+    {% include option.template_name with widget=option %}{% endfor %}{% if group %}
+  </div></div>{% endif %}{% endfor %}
+</div>{% endwith %}

--- a/djng/templates/djng/styling/bootstrap3/radio.html
+++ b/djng/templates/djng/styling/bootstrap3/radio.html
@@ -1,0 +1,4 @@
+{% with id=widget.attrs.id %}<div>{% for group, options, index in widget.optgroups %}{% for option in options %}
+    {% include option.template_name with widget=option %}{% endfor %}{% if group %}
+  </div></div>{% endif %}{% endfor %}
+</div>{% endwith %}

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -1,4 +1,4 @@
-Django>=1.6
+Django>=1.11
 six>=1.8.0
 Pygments>=1.6
 pyquery>=1.2.9

--- a/examples/server/models.py
+++ b/examples/server/models.py
@@ -5,7 +5,7 @@ from django.db import models
 
 class DummyModel(models.Model):
     name = models.CharField(max_length=255)
-    model2 = models.ForeignKey('DummyModel2')
+    model2 = models.ForeignKey('DummyModel2', on_delete=models.CASCADE)
     timefield = models.DateTimeField(default=datetime.datetime.now)
 
 

--- a/examples/server/templatetags/tutorial_tags.py
+++ b/examples/server/templatetags/tutorial_tags.py
@@ -3,7 +3,12 @@ from __future__ import unicode_literals
 import os
 from django import template
 from django.conf import settings
-from django.core.urlresolvers import reverse
+
+try:
+    from django.core.urlresolvers import reverse
+except ImportError:
+    from django.urls import reverse
+
 from pygments import highlight
 from pygments.lexers import PythonLexer
 from pygments.lexers.templates import HtmlDjangoLexer

--- a/examples/server/tests/test_bootstrap3_fields.py
+++ b/examples/server/tests/test_bootstrap3_fields.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+from django import forms
+from django.test import TestCase
+
+from djng.styling.bootstrap3.forms import Bootstrap3Form
+
+from .test_forms import CHOICES
+
+
+class EmailForm(Bootstrap3Form):
+    email = forms.EmailField(label='E-Mail')
+
+class ChoiceForm(Bootstrap3Form):
+    choose = forms.BooleanField(required=True, label='Choose')
+
+class RadioForm(Bootstrap3Form):
+    sex = forms.ChoiceField(choices=(('m', 'Male'), ('f', 'Female')), widget=forms.RadioSelect, required=True)
+
+class ChoicesForm(Bootstrap3Form):
+    check_multi = forms.MultipleChoiceField(choices=CHOICES, widget=forms.CheckboxSelectMultiple)
+
+class SelectMultipleChoicesForm(Bootstrap3Form):
+    select_multi = forms.MultipleChoiceField(choices=CHOICES)
+
+
+class NgFieldRenderBootstrapTestCase(TestCase):
+
+    def test_email_field(self):
+        self.maxDiff = None
+        f = EmailForm({'email': 'test@example.com'})
+        self.assertHTMLEqual(
+            str(f['email']),
+            '''\
+<input type="email" name="email" value="test@example.com" required id="id_email" class="form-control" />''')
+
+    def test_choice_field(self):
+        self.maxDiff = None
+        f = ChoiceForm({'choose': True})
+        self.assertHTMLEqual(
+            str(f['choose']),
+            '''\
+<label class="checkbox-inline">
+    <input type="checkbox" name="choose" checked id="id_choose" required />Choose</label>''')
+
+    def test_radio_field(self):
+        self.maxDiff = None
+        f = RadioForm({'sex': 'f'})
+        self.assertHTMLEqual(
+            str(f['sex']),
+            '''\
+<div>
+    <div class="radio">
+        <label for="id_sex_0"><input type="radio" name="sex" value="m" required id="id_sex_0_0" /> Male</label>
+    </div>
+    <div class="radio">
+        <label for="id_sex_1"><input type="radio" name="sex" value="f" required checked id="id_sex_1_1" /> Female</label>
+    </div>
+</div>''')
+
+    def test_checkbock_select_mulitple_field(self):
+        self.maxDiff = None
+        f = SelectMultipleChoicesForm({'select_multi': ['a', 'c']})
+        self.assertHTMLEqual(
+            str(f['select_multi']),
+            '''\
+<select name="select_multi" required multiple="multiple" class="form-control" id="id_select_multi">
+    <option value="a" selected>Choice A</option>
+    <option value="b">Choice B</option>
+    <option value="c" selected>Choice C</option>
+    <option value="d">Choice D</option>
+</select>
+''')
+
+    def test_checkbock_check_mulitple_field(self):
+        self.maxDiff = None
+        f = ChoicesForm({'check_multi': ['a', 'c']})
+        self.assertHTMLEqual(
+            str(f['check_multi']),
+            '''\
+<div ng-form="check_multi">
+
+<label class="checkbox-inline" for="id_check_multi_0_0"><input type="checkbox" name="check_multi.a"  value="a" checked="checked" id="id_check_multi_0_0"/>Choice A</label>
+
+<label class="checkbox-inline" for="id_check_multi_1_1"><input type="checkbox" name="check_multi.b"  value="b" id="id_check_multi_1_1" />Choice B</label>
+
+<label class="checkbox-inline" for="id_check_multi_2_2"><input type="checkbox" name="check_multi.c"  value="c" checked="checked" id="id_check_multi_2_2" />Choice C</label>
+
+<label class="checkbox-inline" for="id_check_multi_3_3"><input type="checkbox" name="check_multi.d"  value="d" id="id_check_multi_3_3" /> Choice D</label>
+</div>''')  # noqa

--- a/examples/server/tests/test_bootstrap3_fields.py
+++ b/examples/server/tests/test_bootstrap3_fields.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+import unittest
+
+import django
 from django import forms
 from django.test import TestCase
 
@@ -23,6 +26,7 @@ class SelectMultipleChoicesForm(Bootstrap3Form):
     select_multi = forms.MultipleChoiceField(choices=CHOICES)
 
 
+@unittest.skipIf(django.VERSION < (1, 10), "earlier django versions break the html")
 class NgFieldRenderBootstrapTestCase(TestCase):
 
     def test_email_field(self):

--- a/examples/server/tests/test_fields.py
+++ b/examples/server/tests/test_fields.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+import unittest
+
+import django
 from django import forms
 from django.test import TestCase
 from djng.forms import NgFormValidationMixin, NgForm
@@ -25,6 +28,7 @@ class SelectMultipleChoicesForm(BaseForm):
     select_multi = forms.MultipleChoiceField(choices=CHOICES, required=True)
 
 
+@unittest.skipIf(django.VERSION < (1, 10), "earlier django versions break the html")
 class NgFieldRenderTestCase(TestCase):
 
     maxDiff = None
@@ -61,6 +65,7 @@ class NgFieldRenderTestCase(TestCase):
             '''\
 <input id="id_email" name="email" ng-model="email" ng-required="true" type="email" value="test@example.com" required />''')  # noqa
 
+    @unittest.skipIf(django.VERSION < (1, 11), "earlier django versions break the html")
     def test_checkbock_check_mulitple_field(self):
         f = ChoicesForm({'check_multi': ['a', 'c']})
         self.assertHTMLEqual(

--- a/examples/server/tests/test_fields.py
+++ b/examples/server/tests/test_fields.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+from django import forms
+from django.test import TestCase
+from djng.forms import NgFormValidationMixin, NgForm
+
+from .test_forms import CHOICES
+
+
+class BaseForm(NgFormValidationMixin, NgForm):
+    pass
+
+class EmailForm(BaseForm):
+    email = forms.EmailField(label='E-Mail', required=True)
+
+class ChoiceForm(BaseForm):
+    choose = forms.BooleanField(label='Choose', widget=forms.CheckboxInput, required=True)
+
+class RadioForm(BaseForm):
+    sex = forms.ChoiceField(choices=(('m', 'Male'), ('f', 'Female')), widget=forms.RadioSelect, required=True)
+
+class ChoicesForm(BaseForm):
+    check_multi = forms.MultipleChoiceField(choices=CHOICES, widget=forms.CheckboxSelectMultiple, required=True)
+
+class SelectMultipleChoicesForm(BaseForm):
+    select_multi = forms.MultipleChoiceField(choices=CHOICES, required=True)
+
+
+class NgFieldRenderTestCase(TestCase):
+
+    maxDiff = None
+
+    def test_radio_field(self):
+        f = RadioForm({'sex': 'f'})
+        self.assertHTMLEqual(
+            str(f['sex']),
+            '''\
+<ul id="id_sex">
+    <li>
+        <label for="id_sex_0"><input type="radio" name="sex" value="m" required ng-model="sex" id="id_sex_0" />Male</label>
+    </li>
+    <li>
+        <label for="id_sex_1"><input type="radio" name="sex" value="f" required ng-model="sex" id="id_sex_1" checked />Female</label>
+    </li>
+</ul>''')
+
+    def test_choice_field(self):
+        self.maxDiff = None
+        f = ChoiceForm({'choose': True})
+        self.assertHTMLEqual(
+            str(f['choose']),
+            '''\
+<input checked="checked" id="id_choose" name="choose" ng-model="choose" ng-required="true" type="checkbox" required />''')
+
+    def test_email_field(self):
+        import re
+        f = EmailForm({'email': 'test@example.com'})
+        # remove the email regex
+        html = re.sub(r'email-pattern="[^"]+"', '', str(f['email']))
+        self.assertHTMLEqual(
+            html,
+            '''\
+<input id="id_email" name="email" ng-model="email" ng-required="true" type="email" value="test@example.com" required />''')  # noqa
+
+    def test_checkbock_check_mulitple_field(self):
+        f = ChoicesForm({'check_multi': ['a', 'c']})
+        self.assertHTMLEqual(
+            str(f['check_multi']),
+            '''\
+<ul ng-form="check_multi">
+    <li>
+        <label for="id_check_multi_0_0"><input checked="checked" id="id_check_multi_0_0" name="check_multi.a" ng-model="check_multi[&#39;a&#39;]" type="checkbox" value="a" /> Choice A</label>
+    </li>
+    <li>
+        <label for="id_check_multi_1_1"><input id="id_check_multi_1_1" name="check_multi.b" ng-model="check_multi[&#39;b&#39;]" type="checkbox" value="b" /> Choice B</label>
+    </li>
+    <li>
+        <label for="id_check_multi_2_2"><input checked="checked" id="id_check_multi_2_2" name="check_multi.c" ng-model="check_multi[&#39;c&#39;]" type="checkbox" value="c" />Choice C</label>
+    </li>
+    <li>
+        <label for="id_check_multi_3_3"><input id="id_check_multi_3_3" name="check_multi.d" ng-model="check_multi[&#39;d&#39;]" type="checkbox" value="d" /> Choice D</label>
+    </li>
+</ul>''')  # noqa
+
+
+    def test_checkbock_select_mulitple_field(self):
+        f = SelectMultipleChoicesForm({'select_multi': ['a', 'c']})
+        self.assertHTMLEqual(
+            str(f['select_multi']),
+            '''\
+<select multiple="multiple" id="id_select_multi" name="select_multi" ng-model="select_multi" ng-required="true" required>
+    <option value="a" selected="selected">Choice A</option>
+    <option value="b">Choice B</option>
+    <option value="c" selected="selected">Choice C</option>
+    <option value="d">Choice D</option>
+</select>''')   # noqa

--- a/examples/server/tests/test_validation.py
+++ b/examples/server/tests/test_validation.py
@@ -17,7 +17,7 @@ class NgFormValidationMixinTest(TestCase):
         self.maxDiff = None
 
     def test_form(self):
-        self.assertEqual(self.subscription_form.form_name, six.b(self.form_name))
+        self.assertEqual(self.subscription_form.form_name, self.form_name)
 
     def test_ng_length(self):
         first_name = self.dom('input[name=first_name]')

--- a/examples/server/urls.py
+++ b/examples/server/urls.py
@@ -1,6 +1,11 @@
 # -*- coding: utf-8 -*-
 from django.conf.urls import url
-from django.core.urlresolvers import reverse_lazy
+
+try:
+    from django.core.urlresolvers import reverse_lazy
+except ImportError:
+    from django.urls import reverse_lazy
+
 from django.views.generic import RedirectView
 from server.views.classic_subscribe import SubscribeView as ClassicSubscribeView
 from server.views.client_validation import SubscribeView as ClientValidationView

--- a/examples/server/views/classic_subscribe.py
+++ b/examples/server/views/classic_subscribe.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 from server.forms.subscribe_form import SubscribeForm
 # start tutorial
 from django.views.generic.edit import FormView
-from django.core.urlresolvers import reverse_lazy
+from server.urls import reverse_lazy
 
 
 class SubscribeView(FormView):

--- a/examples/server/views/client_validation.py
+++ b/examples/server/views/client_validation.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from server.forms.client_validation import SubscribeForm
+from server.urls import reverse_lazy
 # start tutorial
-from django.core.urlresolvers import reverse_lazy
 from django.views.generic.edit import FormView
 
 

--- a/examples/server/views/combined_validation.py
+++ b/examples/server/views/combined_validation.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 from server.forms.combined_validation import SubscribeForm
+from server.urls import reverse_lazy
 # start tutorial
 import json
 from django.http import HttpResponse
-from django.core.urlresolvers import reverse_lazy
 from django.views.generic.edit import FormView
 from django.utils.encoding import force_text
 

--- a/examples/server/views/model_scope.py
+++ b/examples/server/views/model_scope.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 from server.forms.model_scope import SubscribeForm
+from server.urls import reverse_lazy
 # start tutorial
 import json
 from django.http import HttpResponse
-from django.core.urlresolvers import reverse_lazy
 from django.views.generic.edit import FormView
 from django.utils.encoding import force_text
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length=160
+ignore = E124,E128,E302,E303

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = coverage-clean, py{27,34,35}-django{18,19,110}, coverage-report
+envlist = coverage-clean, py{27,34,35}-django{18,19,110,111}, coverage-report
 skipsdist = true
 
 [testenv]
@@ -20,7 +20,8 @@ deps=
     django-sekizai==0.10
     django18: Django==1.8.14
     django19: Django==1.9.9
-    django110: Django==1.10.4
+    django110: Django==1.10.7
+    django111: Django==1.11.2
 
 [testenv:coverage-clean]
 commands = rm -f .coverage


### PR DESCRIPTION
Hi!,

This adds support for Django 1.11. It was a much larger change than I was expecting but I think it is worth a look. For 1.11 Django completely refactored widget rendering, eliminating the following classes:

* RendererMixin
* ChoiceFieldRenderer
* RadioFieldRenderer
* CheckboxFieldRenderer

https://docs.djangoproject.com/en/1.11/releases/1.11/#template-widget-incompatibilities-1-11

As you know djng relies on those for widget rendering. I moved the old rendering to compat files and updated the widget to use the new template based widget rendering. The urls import location also changed and couple of other minor things. The majority of the work was in the rendering and I created new tests to verify the changes. The new tests pass with Django 1.10 and 1.11 with Python 2 and 3 but do not pass with Django versions < 1.10 as the html output is different.

re https://github.com/jrief/django-angular/issues/284