### PR TITLE
Call current class' get_context method instead of parent's

### DIFF
--- a/djng/forms/angular_base.py
+++ b/djng/forms/angular_base.py
@@ -132,7 +132,7 @@ def get_ng_widget_context(self, name, value, attrs):
     """
     Some widgets require a modified rendering context, if they contain angular directives.
     """
-    context = super(self.__class__, self).get_context(name, value, attrs)
+    context = self.__class__.get_context(self, name, value, attrs)
     if callable(getattr(self._field, 'update_widget_rendering_context', None)):
         self._field.update_widget_rendering_context(context)
     return context


### PR DESCRIPTION
Fixes #297. I haven't noticed any issues introduced by this on Python 2.7, but maybe there was a reason super was being called here?

If this isn't the correct solution, I'll look for a different way of fixing this issue.