### PR TITLE
Fix MRO error introduced in #301

### DIFF
--- a/djng/forms/angular_base.py
+++ b/djng/forms/angular_base.py
@@ -204,7 +204,9 @@ class NgBoundField(forms.BoundField):
         if DJANGO_VERSION > (1, 10):
             # so that we can refer to the field when building the rendering context
             widget._field = self.field
-            widget.__class__ = type(widget.__class__.__name__, (NgWidgetMixin, widget.__class__), {})
+            # Make sure that NgWidgetMixin is not already part of the widget's bases so it doesn't get added twice.
+            if not isinstance(widget, NgWidgetMixin):
+                widget.__class__ = type(widget.__class__.__name__, (NgWidgetMixin, widget.__class__), {})
         return super(NgBoundField, self).as_widget(widget, attrs, only_initial)
 
     def build_widget_attrs(self, attrs, widget=None):

--- a/examples/server/tests/test_forms.py
+++ b/examples/server/tests/test_forms.py
@@ -113,6 +113,12 @@ class NgModelFormMixinTest(TestCase):
         self.dom = PyQuery(htmlsource)
         self.elements = self.dom('input') + self.dom('select')
 
+    def test_widget_mro(self):
+        # render a widget twice to test mro with NgWidgetMixin
+        mro_form = DummyForm()
+        mro_form.as_p()
+        mro_form.as_p()
+
     def test_form_with_custom_args(self):
         form_post_data = {'field1': 'value1', 'field2': 'value2'}
 


### PR DESCRIPTION
If this test is run without applying the fix to `angular_base`, it will cause a `Cannot create a consistent method resolution order (MRO)` error. This is because the `NgWidgetMixin` is added to the DummyForm()'s widgets more than once.
In order to fix this, I added a check to make sure `NgWidgetMixin` is not already in the widget's bases before adding it.