### PR TITLE
Add URLField to fields.py

### DIFF
--- a/djng/forms/fields.py
+++ b/djng/forms/fields.py
@@ -258,6 +258,10 @@ class NullBooleanField(DefaultFieldMixin, fields.NullBooleanField):
     pass
 
 
+class URLField(DefaultFieldMixin, fields.URLField):
+    pass
+
+
 class MultipleFieldMixin(DefaultFieldMixin):
     def get_multiple_choices_required(self):
         """


### PR DESCRIPTION
Not sure if `get_potential_errors` needs to be overridden or not. Our project has some Django URLFields that are not getting converted to Django-Angular URLFields, so I added this stub to fields.py.