### PR TITLE
Use $touched together with $dirty

### DIFF
--- a/djng/forms/angular_base.py
+++ b/djng/forms/angular_base.py
@@ -52,7 +52,6 @@ class TupleErrorList(UserList, list):
     5: The desired error message. If this contains the magic word '$message' it will be added with
        ``ng-bind`` rather than rendered inside the list item.
     """
-    ul_format = '<ul class="{1}" ng-show="{0}.{2}" ng-cloak>{3}</ul>'
     li_format = '<li ng-show="{0}.{1}" class="{2}">{3}</li>'
     li_format_bind = '<li ng-show="{0}.{1}" class="{2}" ng-bind="{0}.{3}"></li>'
 
@@ -104,8 +103,11 @@ class TupleErrorList(UserList, list):
                 err_tuple = (e[0], e[3], e[4], force_text(e[5]))
                 error_lists[e[2]].append(format_html(li_format, *err_tuple))
             # renders and combine both of these lists
-            return mark_safe(''.join([format_html(self.ul_format, first[0], first[1], prop,
-                        mark_safe(''.join(list_items))) for prop, list_items in error_lists.items()]))
+            dirty_errors = format_html('<ul ng-show="{0}.$dirty && {0}.$touched" class="{1}" ng-cloak>{2}</ul>',
+                                       first[0], first[1], mark_safe(''.join(error_lists['$dirty'])))
+            pristine_errors = format_html('<ul ng-show="{0}.$pristine" class="{1}" ng-cloak>{2}</ul>',
+                                          first[0], first[1], mark_safe(''.join(error_lists['$pristine'])))
+            return format_html('{}{}', dirty_errors, pristine_errors)
         return format_html('<ul class="errorlist">{0}</ul>',
             format_html_join('', '<li>{0}</li>', ((force_text(e),) for e in self)))
 

--- a/examples/server/tests/test_model_forms.py
+++ b/examples/server/tests/test_model_forms.py
@@ -54,7 +54,7 @@ class NgModelFormMixinTestCase(TestCase):
         self.assertFalse(f.is_valid())
         soup = BeautifulSoup(f.as_p(), 'lxml')
 
-        ul = soup.find(attrs={'ng-show': "RW1haWxGb3Jt.$dirty"})
+        ul = soup.find(attrs={'ng-show': "RW1haWxGb3Jt.$dirty && RW1haWxGb3Jt.$touched"})
         self.assertListEqual(ul.attrs['class'], ['djng-form-errors'])
         ul = soup.find(attrs={'ng-show': "RW1haWxGb3Jt.$pristine"})
         self.assertListEqual(ul.attrs['class'], ['djng-form-errors'])

--- a/examples/server/tests/test_validation.py
+++ b/examples/server/tests/test_validation.py
@@ -56,14 +56,9 @@ class NgFormValidationMixinTest(TestCase):
 
     def test_field_as_ul(self):
         bf = self.subscription_form['email']
-        ul_dirty = ''.join((
-            '<ul class="djng-form-control-feedback djng-field-errors" ng-show="U3Vic2NyaWJlRm9ybQ[\'email\'].$dirty" ng-cloak>',
-            '<li ng-show="U3Vic2NyaWJlRm9ybQ[\'email\'].$error.required" class="invalid">This field is required.</li>',
-            '<li ng-show="U3Vic2NyaWJlRm9ybQ[\'email\'].$error.email" class="invalid">Enter a valid email address.</li>',
-            '<li ng-show="U3Vic2NyaWJlRm9ybQ[\'email\'].$valid" class="valid"></li>'
-            '</ul>'))
+        ul_dirty = '''<ul ng-show="U3Vic2NyaWJlRm9ybQ['email'].$dirty && U3Vic2NyaWJlRm9ybQ['email'].$touched" class="djng-form-control-feedback djng-field-errors" ng-cloak><li ng-show="U3Vic2NyaWJlRm9ybQ['email'].$error.required" class="invalid">This field is required.</li><li ng-show="U3Vic2NyaWJlRm9ybQ['email'].$error.email" class="invalid">Enter a valid email address.</li><li ng-show="U3Vic2NyaWJlRm9ybQ['email'].$valid" class="valid"></li></ul>'''
         self.assertTrue(ul_dirty in bf.errors.as_ul())
-        ul_pristine = '<ul class="djng-form-control-feedback djng-field-errors" ng-show="U3Vic2NyaWJlRm9ybQ[\'email\'].$pristine" ng-cloak></ul>'
+        ul_pristine = '''<ul ng-show="U3Vic2NyaWJlRm9ybQ['email'].$pristine" class="djng-form-control-feedback djng-field-errors" ng-cloak></ul>'''
         self.assertTrue(ul_pristine in bf.errors.as_ul())
 
     def test_field_as_text(self):

--- a/examples/server/tests/test_validation_forms.py
+++ b/examples/server/tests/test_validation_forms.py
@@ -77,7 +77,7 @@ class NgFormValidationMixinTestCase(TestCase):
         f = RadioForm({'sex': 'f'})
         soup = BeautifulSoup(f.as_p(), 'lxml')
 
-        ul = soup.find(attrs={'ng-show': "UmFkaW9Gb3Jt['sex'].$dirty"})
+        ul = soup.find(attrs={'ng-show': "UmFkaW9Gb3Jt['sex'].$dirty && UmFkaW9Gb3Jt['sex'].$touched"})
         self.assertHTMLEqual(str(ul.li.attrs['ng-show']), 'UmFkaW9Gb3Jt[\'sex\'].$error.required')
         self.assertHTMLEqual(str(ul.li.text), 'This field is required.')
         self.assertHTMLEqual(str(ul.li.nextSibling.attrs['ng-show']), 'UmFkaW9Gb3Jt[\'sex\'].$valid')

--- a/examples/server/tests/test_validation_forms.py
+++ b/examples/server/tests/test_validation_forms.py
@@ -43,7 +43,7 @@ class NgFormValidationMixinTestCase(TestCase):
         f = EmailForm({'email': 'test@example.com'})
         soup = BeautifulSoup(f.as_p(), 'lxml')
 
-        ul = soup.find(attrs={'ng-show': "RW1haWxGb3Jt['email'].$dirty"})
+        ul = soup.find(attrs={'ng-show': "RW1haWxGb3Jt['email'].$dirty && RW1haWxGb3Jt['email'].$touched"})
         self.assertHTMLEqual(str(ul.li), '<li class="invalid" ng-show="RW1haWxGb3Jt[\'email\'].$error.required">This field is required.</li>')
         self.assertHTMLEqual(str(ul.li.nextSibling), '<li class="invalid" ng-show="RW1haWxGb3Jt[\'email\'].$error.email">Enter a valid email address.</li>')
         self.assertHTMLEqual(str(ul.li.nextSibling.nextSibling), '<li class="valid" ng-show="RW1haWxGb3Jt[\'email\'].$valid"></li>')
@@ -61,7 +61,7 @@ class NgFormValidationMixinTestCase(TestCase):
         f = ChoiceForm({'choose': True})
         soup = BeautifulSoup(f.as_p(), 'lxml')
 
-        ul = soup.find(attrs={'ng-show': "Q2hvaWNlRm9ybQ['choose'].$dirty"})
+        ul = soup.find(attrs={'ng-show': "Q2hvaWNlRm9ybQ['choose'].$dirty && Q2hvaWNlRm9ybQ['choose'].$touched"})
         self.assertHTMLEqual(str(ul.li), '<li class="invalid" ng-show="Q2hvaWNlRm9ybQ[\'choose\'].$error.required">This field is required.</li>')
         self.assertHTMLEqual(str(ul.li.nextSibling), '<li class="valid" ng-show="Q2hvaWNlRm9ybQ[\'choose\'].$valid"></li>')
 
@@ -108,7 +108,7 @@ class NgFormValidationMixinTestCase(TestCase):
         f = SelectMultipleChoicesForm({'select_multi': ['a', 'c']})
         soup = BeautifulSoup(f.as_p(), 'lxml')
 
-        ul = soup.find(attrs={'ng-show': "U2VsZWN0TXVsdGlwbGVDaG9pY2VzRm9ybQ['select_multi'].$dirty"})
+        ul = soup.find(attrs={'ng-show': "U2VsZWN0TXVsdGlwbGVDaG9pY2VzRm9ybQ['select_multi'].$dirty && U2VsZWN0TXVsdGlwbGVDaG9pY2VzRm9ybQ['select_multi'].$touched"})
         self.assertListEqual(ul.attrs['class'], ["djng-field-errors"])
         self.assertHTMLEqual(ul.li.attrs['ng-show'], "U2VsZWN0TXVsdGlwbGVDaG9pY2VzRm9ybQ['select_multi'].$error.required")
         self.assertHTMLEqual(ul.li.text, 'This field is required.')
@@ -140,7 +140,7 @@ class NgFormValidationMixinTestCase(TestCase):
         f = CheckboxChoicesForm({'check_multi': ['a', 'c']})
         soup = BeautifulSoup(f.as_p(), 'lxml')
 
-        ul = soup.find(attrs={'ng-show': "Q2hlY2tib3hDaG9pY2VzRm9ybQ['check_multi'].$dirty"})
+        ul = soup.find(attrs={'ng-show': "Q2hlY2tib3hDaG9pY2VzRm9ybQ['check_multi'].$dirty && Q2hlY2tib3hDaG9pY2VzRm9ybQ['check_multi'].$touched"})
         self.assertListEqual(ul.attrs['class'], ["djng-field-errors"])
         self.assertHTMLEqual(str(ul.li.attrs['ng-show']), "Q2hlY2tib3hDaG9pY2VzRm9ybQ['check_multi'].$error.required")
         self.assertHTMLEqual(str(ul.li.text), 'This field is required.')


### PR DESCRIPTION
This fixes #248 and supersedes #260.

Until version 1.1.3, whenever a client typed into a field which at the time did not validate, an error popped up immediately.

Example:
In a form, we define say, a ``CharField(min_length=3)``. If that field is rendered by **django-angular**, it is marked as invalid as soon as the client types the first character. The error message disappears as soon as he entered the third character. This from a usability point of view is not ideal.

Instead with this change, the error message only appears when the field is invalid and loses focus. From my point of view this gives a much nicer user experience.

@adrienbrunet @jkosir what do you think of it? Please review this PR.

@itsjeyd @omarkhan can I extend this to fulfill what you wanted to achieve in #260 ?
