### PR TITLE
deprecate Sekizai’s postprocessors using `with_data`

### DIFF
--- a/djng/sekizai_processors.py
+++ b/djng/sekizai_processors.py
@@ -4,6 +4,8 @@ from __future__ import unicode_literals
 To be used in Sekizai's render_block to postprocess AngularJS module dependenies
 """
 
+import warnings
+
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.html import format_html_join
@@ -15,12 +17,14 @@ if 'sekizai' not in settings.INSTALLED_APPS:
 
 
 def module_list(context, data, namespace):
+    warnings.warn("This postprocessor is deprecated. Read on how to resolve AngularJS dependencies using `{% with_data \"ng-requires\" ... %}`")
     modules = set(m.strip(' "\'') for m in data.split())
     text = format_html_join(', ', '"{0}"', ((m,) for m in modules))
     return text
 
 
 def module_config(context, data, namespace):
+    warnings.warn("This postprocessor is deprecated. Read on how to resolve AngularJS dependencies using `{% with_data \"ng-config\" ... %}`")
     configs = [(mark_safe(c),) for c in data.split('\n') if c]
     text = format_html_join('', '.config({0})', configs)
     return text

--- a/examples/server/templates/base.html
+++ b/examples/server/templates/base.html
@@ -60,9 +60,11 @@
 	{% render_block "js" %}
 
 	<script type="text/javascript">
-	angular.module('djangular-demo', [
-		{% render_block "ng-requires" postprocessor "djng.sekizai_processors.module_list" %}
-	]){% render_block "ng-config" postprocessor "djng.sekizai_processors.module_config" %};
+	angular.module('djangular-demo', [{% with_data "ng-requires" as ng_requires %}
+		{% for module in ng_requires %}'{{ module }}'{% if not forloop.last %}, {% endif %}{% endfor %}{% end_with_data %}])
+	{% with_data "ng-config" as configs %}
+		{% for config in configs %}.config({{ config }}){% endfor %};
+	{% end_with_data %}
 	</script>
 
 	{% block addtoblock %}

--- a/examples/server/templates/image-file-upload.html
+++ b/examples/server/templates/image-file-upload.html
@@ -6,10 +6,10 @@
 	{% addtoblock "css" %}<link href="{% static 'djng/css/fileupload.css' %}" rel="stylesheet" />{% endaddtoblock %}
 	{% addtoblock "js" %}<script src="{% static 'node_modules/ng-file-upload/dist/ng-file-upload.js' %}" type="text/javascript"></script>{% endaddtoblock %}
 	{% addtoblock "js" %}<script src="{% static 'js/djng-fileupload.js' %}" type="text/javascript"></script>{% endaddtoblock %}
-	{% addtoblock "ng-requires" %}djng.fileupload{% endaddtoblock %}
+	{% add_data "ng-requires" "djng.fileupload" %}
 
 	{% addtoblock "js" %}<script src="{% static 'js/djng-urls.js' %}" type="text/javascript"></script>{% endaddtoblock %}
-	{% addtoblock "ng-requires" %}djng.urls{% endaddtoblock %}
+	{% add_data "ng-requires" "djng.urls" %}
 
 	{% addtoblock "ng-config" %}['$httpProvider', function($httpProvider) { $httpProvider.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest'; $httpProvider.defaults.headers.common['X-CSRFToken'] = '{{ csrf_token }}'; }]{% endaddtoblock %}
 	<script src="{% static 'js/model-scope.js' %}" type="text/javascript"></script>

--- a/examples/server/templates/subscribe-form.html
+++ b/examples/server/templates/subscribe-form.html
@@ -4,7 +4,7 @@
 {% block addtoblock %}
 	{{ block.super }}
 	{% addtoblock "js" %}<script src="{% static 'js/djng-forms.js' %}" type="text/javascript"></script>{% endaddtoblock %}
-	{% addtoblock "ng-requires" %}djng.forms{% endaddtoblock %}
+	{% add_data "ng-requires" "djng.forms" %}
 {% endblock %}
 
 {% block main-content %}

--- a/examples/server/templates/three-way-data-binding.html
+++ b/examples/server/templates/three-way-data-binding.html
@@ -6,7 +6,7 @@
 {% block addtoblock %}
 	{{ block.super }}
 	{% addtoblock "js" %}<script src="{% static 'js/djng-websocket.js' %}" type="text/javascript"></script>{% endaddtoblock %}
-	{% addtoblock "ng-requires" %}djng.websocket{% endaddtoblock %}
+	{% add_data "ng-requires" "djng.websocket" %}
 	{% addtoblock "ng-config" %}['djangoWebsocketProvider', function(djangoWebsocketProvider) { djangoWebsocketProvider.setURI('{{ WEBSOCKET_URI }}'); djangoWebsocketProvider.setLogLevel('debug'); djangoWebsocketProvider.setHeartbeat({{ WS4REDIS_HEARTBEAT }}); }]{% endaddtoblock %}
 	<script src="{% static 'js/three-way-data-binding.js' %}" type="text/javascript"></script>
 {% endblock addtoblock %}
@@ -18,13 +18,6 @@
 {% endblock main-intro %}
 
 {% block form_tag %}validate ng-controller="MyWebsocketCtrl"{% endblock %}
-
-{% block container %}
-	{{ block.super }}
-	{% addtoblock "js" %}<script src="{% static 'js/djng-websocket.js' %}" type="text/javascript"></script>{% endaddtoblock %}
-	{% addtoblock "ng-requires" %}djng.websocket{% endaddtoblock %}
-	{% addtoblock "ng-config" %}['djangoWebsocketProvider', function(djangoWebsocketProvider) { djangoWebsocketProvider.setURI('{{ WEBSOCKET_URI }}'); djangoWebsocketProvider.setLogLevel('debug'); djangoWebsocketProvider.setHeartbeat({{ WS4REDIS_HEARTBEAT }}); }]{% endaddtoblock %}
-{% endblock %}
 
 {% block form_foot %}
 	{% verbatim %}


### PR DESCRIPTION
Recently, I discovered the templatetags ``{% add_data ... %}`` and ``{% with_data ... %}`` in [django-sekizai](http://django-sekizai.readthedocs.io/en/latest/index.html#handling-data).

They make the django-angular's own ``sekizai_processor`` obsolete. Instead one can achieve the same functionality with better configuration support using these two tags. Therefore, in django-angular-1.2 I will remove them.