### PR TITLE
fixed: Step 1/43 : FROM fedora-uwsgi-python:24.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM awesto/fedora-uwsgi-python:24.1
+FROM awesto/fedora-uwsgi-python:5
 
 LABEL Description="Run django-angular demo" Maintainer="Jacob Rief <jacob.rief@gmail.com>"
 
@@ -15,7 +15,7 @@ RUN useradd -M -d /web -g uwsgi -s /bin/bash django
 # install the basic Django package
 RUN echo 2 | alternatives --config python
 RUN python -V
-RUN pip install --upgrade pip
+# RUN pip install --upgrade pip
 # RUN pip install --force-reinstall uwsgi
 RUN pip install django==1.10.7
 
@@ -42,7 +42,7 @@ COPY examples/requirements.txt /tmp/requirements.txt
 RUN pip install -r /tmp/requirements.txt
 RUN pip install django-websocket-redis
 
-# install packages outside of PyPI
+# install packages under node_modules/ outside of PyPI
 WORKDIR /web/django-angular-demo
 RUN npm install
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,17 @@ Let Django play well with AngularJS
 [![Software license](https://img.shields.io/pypi/l/django-angular.svg)](https://github.com/jrief/django-angular/blob/master/LICENSE-MIT)
 [![Twitter Follow](https://img.shields.io/twitter/follow/jacobrief.svg?style=social&label=Jacob+Rief)](https://twitter.com/jacobrief)
 
+### How to run
+
+```
+git clone https://github.com/jrief/django-angular.git django-angular.git
+cd django-angular.git
+docker build -t django-angular.git .
+docker run -d -it -p 9002:9002 django-angular.git
+```
+
+Open the applcaiton at `http://{docker-host's-ip}:9002/`
+
 ### Backward Incompatibility
 
 To be compliant with other libraries such as **djangorestframework**,  server-side responses on


### PR DESCRIPTION
repository fedora-uwsgi-python not found: does not exist or no pull access