### PR TITLE
Decode b64encode's binary result to a string

### DIFF
--- a/djng/forms/angular_base.py
+++ b/djng/forms/angular_base.py
@@ -298,7 +298,7 @@ class NgFormBaseMixin(object):
             form_name = self.form_name
         except AttributeError:
             # if form_name is unset, then generate a pseudo unique name, based upon the class name
-            form_name = b64encode(six.b(self.__class__.__name__)).rstrip(six.b('='))
+            form_name = b64encode(six.b(self.__class__.__name__)).rstrip(six.b('=')).decode('ascii')
             if six.PY3:
                 form_name = form_name.decode('utf-8')
         self.form_name = kwargs.pop('form_name', form_name)


### PR DESCRIPTION
A binary-string will come through to the browser incorrectly with newer
python and django versions