### PR TITLE
Remove django.utils.six imports and __future__ imports

### DIFF
--- a/djng/core/urlresolvers.py
+++ b/djng/core/urlresolvers.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 from inspect import isclass
 
-from django.utils import six
+import six
 from django.urls import (get_resolver, get_urlconf, resolve, reverse, NoReverseMatch)
 from django.core.exceptions import ImproperlyConfigured
 

--- a/djng/forms/__init__.py
+++ b/djng/forms/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from django.forms.forms import DeclarativeFieldsMetaclass, BaseForm
 from django.forms.models import BaseModelForm, ModelFormMetaclass
-from django.utils import six
+import six
 from .angular_base import BaseFieldsModifierMetaclass, NgFormBaseMixin
 from .angular_model import NgModelFormMixin
 from .angular_validation import NgFormValidationMixin

--- a/djng/forms/angular_base.py
+++ b/djng/forms/angular_base.py
@@ -14,7 +14,7 @@ import warnings
 from django import VERSION as DJANGO_VERSION
 from django.forms import forms
 from django.http import QueryDict
-from django.utils import six
+import six
 try:
     from importlib import import_module
 except ImportError:

--- a/docs/angular-form-validation.rst
+++ b/docs/angular-form-validation.rst
@@ -24,7 +24,7 @@ this can be achieved automatically and on the fly
 .. code-block:: python
 
 	from django import forms
-	from django.utils import six
+	import six
 	from djng.forms import fields, NgDeclarativeFieldsMetaclass, NgFormValidationMixin
 
 	class MyValidatedForm(six.with_metaclass(NgDeclarativeFieldsMetaclass, NgFormValidationMixin, forms.Form)):

--- a/docs/angular-model-form.rst
+++ b/docs/angular-model-form.rst
@@ -22,7 +22,7 @@ by mixing in the **djng** class ``NgModelFormMixin``
 .. code-block:: python
 
 	from django import forms
-	from django.utils import six
+	import six
 	from djng.forms import fields, NgDeclarativeFieldsMetaclass, NgModelFormMixin
 
 	class ContactForm(six.with_metaclass(NgDeclarativeFieldsMetaclass, NgModelFormMixin, forms.Form)):

--- a/examples/server/tests/test_forms.py
+++ b/examples/server/tests/test_forms.py
@@ -4,7 +4,7 @@ from django.db import models
 from django.forms import forms, widgets
 from django.http import QueryDict
 from django.test import TestCase
-from django.utils import six
+import six
 from djng.forms import fields, NgModelFormMixin, NgForm, NgModelForm, NgDeclarativeFieldsMetaclass, NgFormValidationMixin
 from pyquery.pyquery import PyQuery
 import unittest

--- a/examples/server/tests/test_validation.py
+++ b/examples/server/tests/test_validation.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from base64 import b64encode
 from django import VERSION
-from django.utils import six
+import six
 from django.test import TestCase
 from pyquery.pyquery import PyQuery
 from server.forms.client_validation import SubscribeForm as ClientValidatedForm


### PR DESCRIPTION
This PR allows for compatibility with python3 and django3 projects as the six package has been removed from django.utils