### PR TITLE
docs: Fix simple typo, persited -> persist

### DIFF
--- a/examples/server/settings.py
+++ b/examples/server/settings.py
@@ -142,7 +142,7 @@ try:
     # URL that distinguishes websocket connections from normal requests
     WEBSOCKET_URL = '/ws/'
 
-    # Set the number of seconds each message shall persited
+    # Set the number of seconds each message shall persist
     WS4REDIS_EXPIRE = 3600
 
     WS4REDIS_HEARTBEAT = '--heartbeat--'

--- a/examples/server/tests/settings.py
+++ b/examples/server/tests/settings.py
@@ -120,7 +120,7 @@ try:
     # URL that distinguishes websocket connections from normal requests
     WEBSOCKET_URL = '/ws/'
 
-    # Set the number of seconds each message shall persited
+    # Set the number of seconds each message shall persist
     WS4REDIS_EXPIRE = 3600
 
     WS4REDIS_HEARTBEAT = '--heartbeat--'


### PR DESCRIPTION
There is a small typo in examples/server/settings.py, examples/server/tests/settings.py.

Should read `persist` rather than `persited`.

