### PR TITLE
Remove no-op __future__ imports, Unicode strings

### DIFF
--- a/djng/middleware.py
+++ b/djng/middleware.py
@@ -31,7 +31,7 @@ class AngularUrlMiddleware(MiddlewareMixin):
 
         If it's not replaced we want to reverse to url we get a request to url
         '/angular/reverse/?djng_url_name=orders&djng_url_kwarg_id=' which
-        gives a request.GET QueryDict {u'djng_url_name': [u'orders'], u'djng_url_kwarg_id': [u'']}
+        gives a request.GET QueryDict {'djng_url_name': ['orders'], 'djng_url_kwarg_id': ['']}
 
         In that case we want to ignore the id param and only reverse to url with name 'orders' and no params.
         So we ignore args and kwargs that are empty strings.

--- a/examples/server/forms/client_validation.py
+++ b/examples/server/forms/client_validation.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 # start tutorial
 from django.forms import widgets
 from django.core.exceptions import ValidationError

--- a/examples/server/forms/combined_validation.py
+++ b/examples/server/forms/combined_validation.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 # start tutorial
 from django.core.exceptions import ValidationError
 from django.forms import widgets

--- a/examples/server/forms/forms_set.py
+++ b/examples/server/forms/forms_set.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 # start tutorial
 import re
 from django.core.exceptions import ValidationError

--- a/examples/server/forms/image_file_upload.py
+++ b/examples/server/forms/image_file_upload.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 # start tutorial
 from djng.forms import fields, NgModelFormMixin, NgFormValidationMixin
 from djng.styling.bootstrap3.forms import Bootstrap3Form

--- a/examples/server/forms/model_scope.py
+++ b/examples/server/forms/model_scope.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 # start tutorial
 from django.core.exceptions import ValidationError
 from django.forms import widgets

--- a/examples/server/forms/subscribe_form.py
+++ b/examples/server/forms/subscribe_form.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 # start tutorial
 from django.forms import widgets
 from django.core.exceptions import ValidationError

--- a/examples/server/models/image_file_upload.py
+++ b/examples/server/models/image_file_upload.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 # start tutorial
 from django.db import models
 from djng.forms import NgModelFormMixin, NgFormValidationMixin

--- a/examples/server/settings.py
+++ b/examples/server/settings.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 # Django settings for unit test project.
 import os
 

--- a/examples/server/templatetags/tutorial_tags.py
+++ b/examples/server/templatetags/tutorial_tags.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 import os
 from django import template
 from django.conf import settings

--- a/examples/server/tests/settings.py
+++ b/examples/server/tests/settings.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 """Django settings for unit test project."""
 import os
 

--- a/examples/server/tests/test_fileupload.py
+++ b/examples/server/tests/test_fileupload.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import os, json
 
 from django.conf import settings

--- a/examples/server/tests/test_postprocessor.py
+++ b/examples/server/tests/test_postprocessor.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from django import template
 from django.test import TestCase
 from sekizai.context import SekizaiContext

--- a/examples/server/tests/test_templatetags.py
+++ b/examples/server/tests/test_templatetags.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from django.test import override_settings, TestCase
 from django.test.client import Client
 

--- a/examples/server/tests/test_urlresolver_view.py
+++ b/examples/server/tests/test_urlresolver_view.py
@@ -124,7 +124,7 @@ class TestUrlResolverView(TestCase):
         if six.PY3:
             args = {'params': 'åäö'}
         else:
-            args = {'param': u'åäö'}
+            args = {'param': 'åäö'}
         data = {
             self.url_name_arg: 'home_args',
             self.args_prefix: [1, 2, 3],

--- a/examples/server/tests/test_urlresolvers.py
+++ b/examples/server/tests/test_urlresolvers.py
@@ -30,10 +30,10 @@ class TemplateRemoteMethods(TestCase):
     def test_get_all_remote_methods(self):
         remote_methods = get_all_remote_methods()
         expected = {
-            'urlresolvertags': {'blah': {u'url': '/url_resolvers/', u'headers': {u'DjNg-Remote-Method': 'blah'}, u'method': 'auto'}},
+            'urlresolvertags': {'blah': {'url': '/url_resolvers/', 'headers': {'DjNg-Remote-Method': 'blah'}, 'method': 'auto'}},
             'submethods': {
-                'app': {'foo': {u'url': '/sub_methods/sub/app/', u'headers': {u'DjNg-Remote-Method': 'foo'}, u'method': 'auto'},
-                        'bar': {u'url': '/sub_methods/sub/app/', u'headers': {u'DjNg-Remote-Method': 'bar'}, u'method': 'auto'}},
+                'app': {'foo': {'url': '/sub_methods/sub/app/', 'headers': {'DjNg-Remote-Method': 'foo'}, 'method': 'auto'},
+                        'bar': {'url': '/sub_methods/sub/app/', 'headers': {'DjNg-Remote-Method': 'bar'}, 'method': 'auto'}},
             },
         }
         self.assertDictEqual(remote_methods, expected)

--- a/examples/server/views/classic_subscribe.py
+++ b/examples/server/views/classic_subscribe.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 from server.forms.subscribe_form import SubscribeForm
 # start tutorial
 from django.views.generic.edit import FormView

--- a/examples/server/views/forms_set.py
+++ b/examples/server/views/forms_set.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 from server.forms.forms_set import SubscribeForm, AddressForm
 # start tutorial
 import json


### PR DESCRIPTION
Version 2.3 officially dropped support for Python 2.7 (which reached its end of life at the end of 2020).

In Python 3, all string literals are Unicode.

Expressly stating file encoding (with `# -*- coding: utf-8 -*-`) is no longer necessary (files now default to being interpreted as UTF-8 instead of ASCII), but it's somewhat harmless.