### PR TITLE
docs: Fix a few typos

### DIFF
--- a/client/src/js/djng-rmi.js
+++ b/client/src/js/djng-rmi.js
@@ -10,7 +10,7 @@ var djng_rmi_module = angular.module('djng.rmi', []);
 // by $http.get() and $http.post().
 // Usage:
 // djangoRMI.name.method(data).success(...).error(...)
-// @param data (optional): If set and @allowd_action was auto, then the call is performed as method
+// @param data (optional): If set and @allowed_action was auto, then the call is performed as method
 //     POST. If data is unset, method GET is used. data must be a valid JavaScript object or undefined.
 djng_rmi_module.provider('djangoRMI', function() {
 	var remote_methods, http;

--- a/djng/forms/widgets.py
+++ b/djng/forms/widgets.py
@@ -35,7 +35,7 @@ class DropFileWidget(widgets.Widget):
         final_attrs = self.build_attrs(self.attrs, extra_attrs=extra_attrs)
         elements = [format_html('<textarea {}>{}</textarea>', flatatt(final_attrs), self.area_label)]
 
-        # add a spinnging wheel
+        # add a spinning wheel
         spinner_attrs = {
             'class': 'glyphicon glyphicon-refresh glyphicon-spin',
             'ng-cloak': True,

--- a/djng/sekizai_processors.py
+++ b/djng/sekizai_processors.py
@@ -1,5 +1,5 @@
 """
-To be used in Sekizai's render_block to postprocess AngularJS module dependenies
+To be used in Sekizai's render_block to postprocess AngularJS module dependencies
 """
 
 import warnings

--- a/docs/basic-crud-operations.rst
+++ b/docs/basic-crud-operations.rst
@@ -128,7 +128,7 @@ By default, ``NgCRUDView`` maps the request to the corresponding django-angular 
 the ``ng_delete`` method.
 
 ``allowed_methods`` is set by default to ``['GET', 'POST', 'DELETE']``.
-If you need to prevent any method, you can overrride the ``allowed_methods`` attributes. Alternatively, you can use the ``exclude_methods`` attributes.
+If you need to prevent any method, you can override the ``allowed_methods`` attributes. Alternatively, you can use the ``exclude_methods`` attributes.
 
 
 ``exclude_methods``

--- a/docs/demos.rst
+++ b/docs/demos.rst
@@ -88,7 +88,7 @@ a different constraint:
 * *Last name* must start with a capital letter.
 * *E-Mail* must be a valid address.
 * *Phone number* can start with ``+`` and may contain only digits, spaces and dashes.
-* *Birth date* must be a vaild date.
+* *Birth date* must be a valid date.
 * *Weight* must be an integer between 42 and 95.
 * *Height* must be a float value between 1.48 and 1.95.
 

--- a/docs/upload-files.rst
+++ b/docs/upload-files.rst
@@ -23,7 +23,7 @@ input field, which immediately displays the uploaded image. By adding two third 
 By replacing Django's form fields ``FileField`` against :class:`djng.forms.fields.FileField` and
 ``ImageField`` against :class:`djng.forms.fields.ImageField`, the corresponding form field is
 rendered as a rectangular area, where one can drag a file or image onto, and drop it. It then is
-uploaded immediately to the server, which keeps it in a temporary folder and returns a thumbail
+uploaded immediately to the server, which keeps it in a temporary folder and returns a thumbnail
 of that file/image together with a reference onto a temporary representation.
 
 In the next step, when the user submits the form, only the reference to that temporary file is


### PR DESCRIPTION
There are small typos in:
- client/src/js/djng-rmi.js
- djng/forms/widgets.py
- djng/sekizai_processors.py
- docs/basic-crud-operations.rst
- docs/demos.rst
- docs/upload-files.rst

Fixes:
- Should read `valid` rather than `vaild`.
- Should read `thumbnail` rather than `thumbail`.
- Should read `spinning` rather than `spinnging`.
- Should read `override` rather than `overrride`.
- Should read `dependencies` rather than `dependenies`.
- Should read `allowed` rather than `allowd`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md